### PR TITLE
add notebook to execute all translation notebooks

### DIFF
--- a/metadata-translation/notebooks/README.md
+++ b/metadata-translation/notebooks/README.md
@@ -15,10 +15,12 @@ You exit the environment by executing the command `deactivate` in the terminal.
 
 ## Translation workflow
 
-The metadata translation workflow consists of the notebooks executed in the following order:
+The [translation pipeline](https://github.com/microbiomedata/nmdc-metadata/blob/master/metadata-translation/notebooks/translation-pipeline.ipynb) notebook translates metadata to JSON. Operationally, it executes the following notebooks in order:
 1. [Translate GOLD study, project, biosample](https://github.com/microbiomedata/nmdc-metadata/blob/master/metadata-translation/notebooks/translate-GOLD-study-project-biosample.ipynb)
 2. [Translate GOLD data objects](https://github.com/microbiomedata/nmdc-metadata/blob/master/metadata-translation/notebooks/translate-GOLD-data-objects.ipynb)
 3. [Translate EMSL data](https://github.com/microbiomedata/nmdc-metadata/blob/master/metadata-translation/notebooks/translate-EMSL-data.ipynb)
+
+The final output is saved to the directory `./output/nmdc-json/`.
 
 A high-level overview of the translation process is depicted below. At each step, metadata and the [NMDC schema](lib/nmdc.py) are input into the translation notebook, and JSON files are created. The output of the last step is forwarded to the web-development team for ingestion and display on the [NMDC pilot site](https://microbiomedata.github.io/pilot/).  
 

--- a/metadata-translation/notebooks/translation-pipeline.ipynb
+++ b/metadata-translation/notebooks/translation-pipeline.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Translation pipeline\n",
+    "This notebook provides a single place to translate the metadagta data to JSON. It executes the translation notebooks in order:\n",
+    "1. `translate-GOLD-study-project-biosample.ipynb`\n",
+    "2. `translate-GOLD-data-objects.ipynb`\n",
+    "3. `translate-EMSL-data.ipynb`  \n",
+    "\n",
+    "The final output is saved to the directory `./output/nmdc-json/`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run \"translate-GOLD-study-project-biosample.ipynb\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run \"translate-GOLD-data-objects.ipynb\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run \"translate-EMSL-data.ipynb\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Fixes #52 
Using papermill at this point is overkill. You can simply use the magic command `%run notebook.ipynb`. Perhaps papermill might be appropriate in the future.