### PR TITLE
Adding more activity/data object examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ env.lock:
 	cp /dev/null env.lock
 
 # TODO: nmdc-02
-schema_test_examples = nmdc-01 functional-annotation feature-set
+schema_test_examples = nmdc-01 functional-annotation feature-set img_mg_annotation_data_objects img_mg_annotation_objects
 
 test_jsonschema: $(patsubst %, schema/test-%.valid, $(schema_test_examples))
 test: test_jsonschema pytest

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ schema_uml: schema/nmdc_schema_uml.png
 schema/%.py: schema/%.yaml env.lock
 	pipenv run gen-py-classes $< > $@.tmp && pipenv run python $@.tmp && mv $@.tmp $@
 
+#.PHONY: force_schema_build
+#force_schema_build: schema/nmdc.yaml schema/prov.yaml schema/core.yaml  schema/annotation.yaml
+
 # JSON Schema
 schema/nmdc.schema.json: schema/nmdc.yaml env.lock
 	pipenv run gen-json-schema -t database $<  > $@.tmp && jsonschema $@.tmp && mv $@.tmp $@

--- a/examples/img_mg_annotation_data_objects.json
+++ b/examples/img_mg_annotation_data_objects.json
@@ -1,0 +1,4564 @@
+{"data_object_set":
+[
+  {
+    "description": "EC TSV File for gold:Gp0153825", 
+    "url": "https://data.microbiomedata.org/1777_118770/img_annotation/Ga0482144_ec.tsv", 
+    "md5_checksum": "a1f2c190aa6d470f2eea681126e0470e", 
+    "file_size_bytes": 100494, 
+    "id": "nmdc:a1f2c190aa6d470f2eea681126e0470e", 
+    "name": "gold:Gp0153825_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0153825", 
+    "url": "https://data.microbiomedata.org/1777_118770/img_annotation/Ga0482144_ko.tsv", 
+    "md5_checksum": "7d69d28f4abec72a7ad66411312c37fb", 
+    "file_size_bytes": 165429, 
+    "id": "nmdc:7d69d28f4abec72a7ad66411312c37fb", 
+    "name": "gold:Gp0153825_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0153825", 
+    "url": "https://data.microbiomedata.org/1777_118770/img_annotation/Ga0482144_functional_annotation.gff", 
+    "md5_checksum": "c3ea4b3caf0c86e27118b3ffd51014b8", 
+    "file_size_bytes": 1121008, 
+    "id": "nmdc:c3ea4b3caf0c86e27118b3ffd51014b8", 
+    "name": "gold:Gp0153825_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0153825", 
+    "url": "https://data.microbiomedata.org/1777_118770/img_annotation/Ga0482144_proteins.faa", 
+    "md5_checksum": "a79973ef9a0c96d13fa19b2725b21d17", 
+    "file_size_bytes": 1389202, 
+    "id": "nmdc:a79973ef9a0c96d13fa19b2725b21d17", 
+    "name": "gold:Gp0153825_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0153825", 
+    "url": "https://data.microbiomedata.org/1777_118770/img_annotation/Ga0482144_structural_annotation.gff", 
+    "md5_checksum": "1055b8fab0f63a1e56312813f47897ec", 
+    "file_size_bytes": 543390, 
+    "id": "nmdc:1055b8fab0f63a1e56312813f47897ec", 
+    "name": "gold:Gp0153825_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119849", 
+    "url": "https://data.microbiomedata.org/1777_95818/img_annotation/Ga0482166_ec.tsv", 
+    "md5_checksum": "b7abebe872fb705d2cdd5fcd36becf0e", 
+    "file_size_bytes": 613278, 
+    "id": "nmdc:b7abebe872fb705d2cdd5fcd36becf0e", 
+    "name": "gold:Gp0119849_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119849", 
+    "url": "https://data.microbiomedata.org/1777_95818/img_annotation/Ga0482166_ko.tsv", 
+    "md5_checksum": "5b2e3bf2abc084710300eb4668638ed3", 
+    "file_size_bytes": 1000645, 
+    "id": "nmdc:5b2e3bf2abc084710300eb4668638ed3", 
+    "name": "gold:Gp0119849_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119849", 
+    "url": "https://data.microbiomedata.org/1777_95818/img_annotation/Ga0482166_functional_annotation.gff", 
+    "md5_checksum": "f574e3392aa40d786a566ae4bc0a5932", 
+    "file_size_bytes": 6694088, 
+    "id": "nmdc:f574e3392aa40d786a566ae4bc0a5932", 
+    "name": "gold:Gp0119849_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119849", 
+    "url": "https://data.microbiomedata.org/1777_95818/img_annotation/Ga0482166_proteins.faa", 
+    "md5_checksum": "c09c5f5c4f776e6250cf35003e939729", 
+    "file_size_bytes": 7077445, 
+    "id": "nmdc:c09c5f5c4f776e6250cf35003e939729", 
+    "name": "gold:Gp0119849_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119849", 
+    "url": "https://data.microbiomedata.org/1777_95818/img_annotation/Ga0482166_structural_annotation.gff", 
+    "md5_checksum": "fd3023efdffe55105bc192f5b6cb4675", 
+    "file_size_bytes": 3429306, 
+    "id": "nmdc:fd3023efdffe55105bc192f5b6cb4675", 
+    "name": "gold:Gp0119849_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119850", 
+    "url": "https://data.microbiomedata.org/1777_95819/img_annotation/Ga0482165_ec.tsv", 
+    "md5_checksum": "dd84dbd2e1b611a1cb6f855f578538d3", 
+    "file_size_bytes": 523765, 
+    "id": "nmdc:dd84dbd2e1b611a1cb6f855f578538d3", 
+    "name": "gold:Gp0119850_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119850", 
+    "url": "https://data.microbiomedata.org/1777_95819/img_annotation/Ga0482165_ko.tsv", 
+    "md5_checksum": "72bc285bcb9a4e0bff1b99719cf8346b", 
+    "file_size_bytes": 866383, 
+    "id": "nmdc:72bc285bcb9a4e0bff1b99719cf8346b", 
+    "name": "gold:Gp0119850_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119850", 
+    "url": "https://data.microbiomedata.org/1777_95819/img_annotation/Ga0482165_functional_annotation.gff", 
+    "md5_checksum": "e18017e4d7721b9aa8f6fe0604d61d28", 
+    "file_size_bytes": 5465244, 
+    "id": "nmdc:e18017e4d7721b9aa8f6fe0604d61d28", 
+    "name": "gold:Gp0119850_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119850", 
+    "url": "https://data.microbiomedata.org/1777_95819/img_annotation/Ga0482165_proteins.faa", 
+    "md5_checksum": "c93e3ebaf3c21c50bb1071d0e07daa48", 
+    "file_size_bytes": 5742437, 
+    "id": "nmdc:c93e3ebaf3c21c50bb1071d0e07daa48", 
+    "name": "gold:Gp0119850_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119850", 
+    "url": "https://data.microbiomedata.org/1777_95819/img_annotation/Ga0482165_structural_annotation.gff", 
+    "md5_checksum": "6e16b6f3d73dc771eba4c729600c9551", 
+    "file_size_bytes": 2743370, 
+    "id": "nmdc:6e16b6f3d73dc771eba4c729600c9551", 
+    "name": "gold:Gp0119850_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119851", 
+    "url": "https://data.microbiomedata.org/1777_95820/img_annotation/Ga0482164_ec.tsv", 
+    "md5_checksum": "bdfa927dbe2d5bbf27f1a1cf0265a27f", 
+    "file_size_bytes": 661277, 
+    "id": "nmdc:bdfa927dbe2d5bbf27f1a1cf0265a27f", 
+    "name": "gold:Gp0119851_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119851", 
+    "url": "https://data.microbiomedata.org/1777_95820/img_annotation/Ga0482164_ko.tsv", 
+    "md5_checksum": "0ab4c3c5fb624a9931ac977df5a4aa4f", 
+    "file_size_bytes": 1100587, 
+    "id": "nmdc:0ab4c3c5fb624a9931ac977df5a4aa4f", 
+    "name": "gold:Gp0119851_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119851", 
+    "url": "https://data.microbiomedata.org/1777_95820/img_annotation/Ga0482164_functional_annotation.gff", 
+    "md5_checksum": "4b6e2700378acc2a9ac22195a9b4cbfb", 
+    "file_size_bytes": 7511774, 
+    "id": "nmdc:4b6e2700378acc2a9ac22195a9b4cbfb", 
+    "name": "gold:Gp0119851_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119851", 
+    "url": "https://data.microbiomedata.org/1777_95820/img_annotation/Ga0482164_proteins.faa", 
+    "md5_checksum": "f8219a779a150e71c672dd2bfd695365", 
+    "file_size_bytes": 8579293, 
+    "id": "nmdc:f8219a779a150e71c672dd2bfd695365", 
+    "name": "gold:Gp0119851_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119851", 
+    "url": "https://data.microbiomedata.org/1777_95820/img_annotation/Ga0482164_structural_annotation.gff", 
+    "md5_checksum": "adfd5d1e9ec99ea5917d8b9efdbd9130", 
+    "file_size_bytes": 3817304, 
+    "id": "nmdc:adfd5d1e9ec99ea5917d8b9efdbd9130", 
+    "name": "gold:Gp0119851_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119852", 
+    "url": "https://data.microbiomedata.org/1777_95821/img_annotation/Ga0482163_ec.tsv", 
+    "md5_checksum": "de071cd0e3010778b9f491e846b95179", 
+    "file_size_bytes": 432746, 
+    "id": "nmdc:de071cd0e3010778b9f491e846b95179", 
+    "name": "gold:Gp0119852_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119852", 
+    "url": "https://data.microbiomedata.org/1777_95821/img_annotation/Ga0482163_ko.tsv", 
+    "md5_checksum": "793aa923c27dd8cc762625f96ff52f80", 
+    "file_size_bytes": 707061, 
+    "id": "nmdc:793aa923c27dd8cc762625f96ff52f80", 
+    "name": "gold:Gp0119852_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119852", 
+    "url": "https://data.microbiomedata.org/1777_95821/img_annotation/Ga0482163_functional_annotation.gff", 
+    "md5_checksum": "678d467ad6c4ad6d7ba2f259585c4acd", 
+    "file_size_bytes": 4418894, 
+    "id": "nmdc:678d467ad6c4ad6d7ba2f259585c4acd", 
+    "name": "gold:Gp0119852_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119852", 
+    "url": "https://data.microbiomedata.org/1777_95821/img_annotation/Ga0482163_proteins.faa", 
+    "md5_checksum": "18c7f9fe5340509f00326c70c1815e88", 
+    "file_size_bytes": 4718032, 
+    "id": "nmdc:18c7f9fe5340509f00326c70c1815e88", 
+    "name": "gold:Gp0119852_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119852", 
+    "url": "https://data.microbiomedata.org/1777_95821/img_annotation/Ga0482163_structural_annotation.gff", 
+    "md5_checksum": "4b43a24ab20530a72e06a8721b2c09db", 
+    "file_size_bytes": 2162108, 
+    "id": "nmdc:4b43a24ab20530a72e06a8721b2c09db", 
+    "name": "gold:Gp0119852_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119853", 
+    "url": "https://data.microbiomedata.org/1777_95822/img_annotation/Ga0482162_ec.tsv", 
+    "md5_checksum": "2bd72614bf1a394de064eb6148074d22", 
+    "file_size_bytes": 1098326, 
+    "id": "nmdc:2bd72614bf1a394de064eb6148074d22", 
+    "name": "gold:Gp0119853_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119853", 
+    "url": "https://data.microbiomedata.org/1777_95822/img_annotation/Ga0482162_ko.tsv", 
+    "md5_checksum": "af374a8de732aa3c85eba74b5d29fb66", 
+    "file_size_bytes": 1827069, 
+    "id": "nmdc:af374a8de732aa3c85eba74b5d29fb66", 
+    "name": "gold:Gp0119853_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119853", 
+    "url": "https://data.microbiomedata.org/1777_95822/img_annotation/Ga0482162_functional_annotation.gff", 
+    "md5_checksum": "db7baf32a8a49b586b8ff70b67487863", 
+    "file_size_bytes": 12621202, 
+    "id": "nmdc:db7baf32a8a49b586b8ff70b67487863", 
+    "name": "gold:Gp0119853_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119853", 
+    "url": "https://data.microbiomedata.org/1777_95822/img_annotation/Ga0482162_proteins.faa", 
+    "md5_checksum": "c0c580b59189351b4f4919701e4db0f2", 
+    "file_size_bytes": 15101364, 
+    "id": "nmdc:c0c580b59189351b4f4919701e4db0f2", 
+    "name": "gold:Gp0119853_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119853", 
+    "url": "https://data.microbiomedata.org/1777_95822/img_annotation/Ga0482162_structural_annotation.gff", 
+    "md5_checksum": "14e390786d1f1eb60835aca96081ab23", 
+    "file_size_bytes": 6333203, 
+    "id": "nmdc:14e390786d1f1eb60835aca96081ab23", 
+    "name": "gold:Gp0119853_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119854", 
+    "url": "https://data.microbiomedata.org/1777_95823/img_annotation/Ga0482161_ec.tsv", 
+    "md5_checksum": "93e586051957e0f4a451b70ceeac04ab", 
+    "file_size_bytes": 996765, 
+    "id": "nmdc:93e586051957e0f4a451b70ceeac04ab", 
+    "name": "gold:Gp0119854_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119854", 
+    "url": "https://data.microbiomedata.org/1777_95823/img_annotation/Ga0482161_ko.tsv", 
+    "md5_checksum": "6b974729dc47b7795b17fac36d496cfa", 
+    "file_size_bytes": 1637996, 
+    "id": "nmdc:6b974729dc47b7795b17fac36d496cfa", 
+    "name": "gold:Gp0119854_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119854", 
+    "url": "https://data.microbiomedata.org/1777_95823/img_annotation/Ga0482161_functional_annotation.gff", 
+    "md5_checksum": "3361194f90da2d18830213cd4587aa71", 
+    "file_size_bytes": 11053322, 
+    "id": "nmdc:3361194f90da2d18830213cd4587aa71", 
+    "name": "gold:Gp0119854_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119854", 
+    "url": "https://data.microbiomedata.org/1777_95823/img_annotation/Ga0482161_proteins.faa", 
+    "md5_checksum": "dba970c890226f16b008f8043ca38d9b", 
+    "file_size_bytes": 13012096, 
+    "id": "nmdc:dba970c890226f16b008f8043ca38d9b", 
+    "name": "gold:Gp0119854_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119854", 
+    "url": "https://data.microbiomedata.org/1777_95823/img_annotation/Ga0482161_structural_annotation.gff", 
+    "md5_checksum": "b476e6c11fed4a3254eda4d15a4183c7", 
+    "file_size_bytes": 5494784, 
+    "id": "nmdc:b476e6c11fed4a3254eda4d15a4183c7", 
+    "name": "gold:Gp0119854_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119855", 
+    "url": "https://data.microbiomedata.org/1777_95824/img_annotation/Ga0482160_ec.tsv", 
+    "md5_checksum": "465d9547f4c5d5aa4d341555f5769d9a", 
+    "file_size_bytes": 1003660, 
+    "id": "nmdc:465d9547f4c5d5aa4d341555f5769d9a", 
+    "name": "gold:Gp0119855_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119855", 
+    "url": "https://data.microbiomedata.org/1777_95824/img_annotation/Ga0482160_ko.tsv", 
+    "md5_checksum": "34a4bbe14e8867d45e95e205738b6d3f", 
+    "file_size_bytes": 1672430, 
+    "id": "nmdc:34a4bbe14e8867d45e95e205738b6d3f", 
+    "name": "gold:Gp0119855_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119855", 
+    "url": "https://data.microbiomedata.org/1777_95824/img_annotation/Ga0482160_functional_annotation.gff", 
+    "md5_checksum": "7a953d15a0f368c71cb365c2dd888a83", 
+    "file_size_bytes": 11371309, 
+    "id": "nmdc:7a953d15a0f368c71cb365c2dd888a83", 
+    "name": "gold:Gp0119855_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119855", 
+    "url": "https://data.microbiomedata.org/1777_95824/img_annotation/Ga0482160_proteins.faa", 
+    "md5_checksum": "bb8a58ce8c8850f95dc84aa49a7a96f7", 
+    "file_size_bytes": 13550077, 
+    "id": "nmdc:bb8a58ce8c8850f95dc84aa49a7a96f7", 
+    "name": "gold:Gp0119855_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119855", 
+    "url": "https://data.microbiomedata.org/1777_95824/img_annotation/Ga0482160_structural_annotation.gff", 
+    "md5_checksum": "3a05f63e1899f82d11d931adfe69d86a", 
+    "file_size_bytes": 5646969, 
+    "id": "nmdc:3a05f63e1899f82d11d931adfe69d86a", 
+    "name": "gold:Gp0119855_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119856", 
+    "url": "https://data.microbiomedata.org/1777_95825/img_annotation/Ga0482159_ec.tsv", 
+    "md5_checksum": "e1c28a3028e3fb994d48c67c3cad4ab4", 
+    "file_size_bytes": 722889, 
+    "id": "nmdc:e1c28a3028e3fb994d48c67c3cad4ab4", 
+    "name": "gold:Gp0119856_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119856", 
+    "url": "https://data.microbiomedata.org/1777_95825/img_annotation/Ga0482159_ko.tsv", 
+    "md5_checksum": "41b3a8590d7ad384f5a92bfd74267f5f", 
+    "file_size_bytes": 1150133, 
+    "id": "nmdc:41b3a8590d7ad384f5a92bfd74267f5f", 
+    "name": "gold:Gp0119856_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119856", 
+    "url": "https://data.microbiomedata.org/1777_95825/img_annotation/Ga0482159_functional_annotation.gff", 
+    "md5_checksum": "5726d2d4081cd3a257e15e98f5a45f8c", 
+    "file_size_bytes": 8102790, 
+    "id": "nmdc:5726d2d4081cd3a257e15e98f5a45f8c", 
+    "name": "gold:Gp0119856_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119856", 
+    "url": "https://data.microbiomedata.org/1777_95825/img_annotation/Ga0482159_proteins.faa", 
+    "md5_checksum": "42164be43a9ab6da393c7d48825e289e", 
+    "file_size_bytes": 7825045, 
+    "id": "nmdc:42164be43a9ab6da393c7d48825e289e", 
+    "name": "gold:Gp0119856_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119856", 
+    "url": "https://data.microbiomedata.org/1777_95825/img_annotation/Ga0482159_structural_annotation.gff", 
+    "md5_checksum": "72aaf6784de9aa35be58e12898bff353", 
+    "file_size_bytes": 4257329, 
+    "id": "nmdc:72aaf6784de9aa35be58e12898bff353", 
+    "name": "gold:Gp0119856_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119857", 
+    "url": "https://data.microbiomedata.org/1777_95826/img_annotation/Ga0482158_ec.tsv", 
+    "md5_checksum": "ecbfb703f2b4204f9f67de20840bd355", 
+    "file_size_bytes": 510020, 
+    "id": "nmdc:ecbfb703f2b4204f9f67de20840bd355", 
+    "name": "gold:Gp0119857_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119857", 
+    "url": "https://data.microbiomedata.org/1777_95826/img_annotation/Ga0482158_ko.tsv", 
+    "md5_checksum": "60524c5c69a1c8b4a2609f4a9cb3a490", 
+    "file_size_bytes": 847038, 
+    "id": "nmdc:60524c5c69a1c8b4a2609f4a9cb3a490", 
+    "name": "gold:Gp0119857_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119857", 
+    "url": "https://data.microbiomedata.org/1777_95826/img_annotation/Ga0482158_functional_annotation.gff", 
+    "md5_checksum": "4a4032318b50bdc3bae5d290a7f0735e", 
+    "file_size_bytes": 5795401, 
+    "id": "nmdc:4a4032318b50bdc3bae5d290a7f0735e", 
+    "name": "gold:Gp0119857_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119857", 
+    "url": "https://data.microbiomedata.org/1777_95826/img_annotation/Ga0482158_proteins.faa", 
+    "md5_checksum": "5a77bb24847fcbf1c3fec6c40aa2ac14", 
+    "file_size_bytes": 6594650, 
+    "id": "nmdc:5a77bb24847fcbf1c3fec6c40aa2ac14", 
+    "name": "gold:Gp0119857_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119857", 
+    "url": "https://data.microbiomedata.org/1777_95826/img_annotation/Ga0482158_structural_annotation.gff", 
+    "md5_checksum": "89ef0619642dead830035ac9389ca802", 
+    "file_size_bytes": 2951076, 
+    "id": "nmdc:89ef0619642dead830035ac9389ca802", 
+    "name": "gold:Gp0119857_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119858", 
+    "url": "https://data.microbiomedata.org/1777_95827/img_annotation/Ga0482157_ec.tsv", 
+    "md5_checksum": "db4fc71545bef12273f70878ad83a7fe", 
+    "file_size_bytes": 263147, 
+    "id": "nmdc:db4fc71545bef12273f70878ad83a7fe", 
+    "name": "gold:Gp0119858_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119858", 
+    "url": "https://data.microbiomedata.org/1777_95827/img_annotation/Ga0482157_ko.tsv", 
+    "md5_checksum": "503667333d0a31fa41da4885bea45c8c", 
+    "file_size_bytes": 437721, 
+    "id": "nmdc:503667333d0a31fa41da4885bea45c8c", 
+    "name": "gold:Gp0119858_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119858", 
+    "url": "https://data.microbiomedata.org/1777_95827/img_annotation/Ga0482157_functional_annotation.gff", 
+    "md5_checksum": "8e0746f6759e85ee867f85191d83a1e9", 
+    "file_size_bytes": 3061304, 
+    "id": "nmdc:8e0746f6759e85ee867f85191d83a1e9", 
+    "name": "gold:Gp0119858_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119858", 
+    "url": "https://data.microbiomedata.org/1777_95827/img_annotation/Ga0482157_proteins.faa", 
+    "md5_checksum": "0b7a5694aefdea2070dd1b21a21a9abb", 
+    "file_size_bytes": 3628466, 
+    "id": "nmdc:0b7a5694aefdea2070dd1b21a21a9abb", 
+    "name": "gold:Gp0119858_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119858", 
+    "url": "https://data.microbiomedata.org/1777_95827/img_annotation/Ga0482157_structural_annotation.gff", 
+    "md5_checksum": "43157d8de38b673ce4a4d70ee3a1198c", 
+    "file_size_bytes": 1520231, 
+    "id": "nmdc:43157d8de38b673ce4a4d70ee3a1198c", 
+    "name": "gold:Gp0119858_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119859", 
+    "url": "https://data.microbiomedata.org/1777_95828/img_annotation/Ga0482156_ec.tsv", 
+    "md5_checksum": "ed4bc44713888809173573d96114f11e", 
+    "file_size_bytes": 222265, 
+    "id": "nmdc:ed4bc44713888809173573d96114f11e", 
+    "name": "gold:Gp0119859_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119859", 
+    "url": "https://data.microbiomedata.org/1777_95828/img_annotation/Ga0482156_ko.tsv", 
+    "md5_checksum": "18cdf12e824a7fb6255dbcac79a2a9a0", 
+    "file_size_bytes": 379622, 
+    "id": "nmdc:18cdf12e824a7fb6255dbcac79a2a9a0", 
+    "name": "gold:Gp0119859_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119859", 
+    "url": "https://data.microbiomedata.org/1777_95828/img_annotation/Ga0482156_functional_annotation.gff", 
+    "md5_checksum": "1729d54d35a1445759d4a85cbd4e305c", 
+    "file_size_bytes": 2833302, 
+    "id": "nmdc:1729d54d35a1445759d4a85cbd4e305c", 
+    "name": "gold:Gp0119859_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119859", 
+    "url": "https://data.microbiomedata.org/1777_95828/img_annotation/Ga0482156_proteins.faa", 
+    "md5_checksum": "eb09f7f461ad13a47bf5609cdcfc853c", 
+    "file_size_bytes": 3742268, 
+    "id": "nmdc:eb09f7f461ad13a47bf5609cdcfc853c", 
+    "name": "gold:Gp0119859_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119859", 
+    "url": "https://data.microbiomedata.org/1777_95828/img_annotation/Ga0482156_structural_annotation.gff", 
+    "md5_checksum": "10128acfa04b42839c133fe298eab941", 
+    "file_size_bytes": 1402495, 
+    "id": "nmdc:10128acfa04b42839c133fe298eab941", 
+    "name": "gold:Gp0119859_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119860", 
+    "url": "https://data.microbiomedata.org/1777_95829/img_annotation/Ga0482155_ec.tsv", 
+    "md5_checksum": "cf2282967219cfc4462f91840aae4126", 
+    "file_size_bytes": 234980, 
+    "id": "nmdc:cf2282967219cfc4462f91840aae4126", 
+    "name": "gold:Gp0119860_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119860", 
+    "url": "https://data.microbiomedata.org/1777_95829/img_annotation/Ga0482155_ko.tsv", 
+    "md5_checksum": "7137d225d4e84d63175b89e1f74b7728", 
+    "file_size_bytes": 400634, 
+    "id": "nmdc:7137d225d4e84d63175b89e1f74b7728", 
+    "name": "gold:Gp0119860_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119860", 
+    "url": "https://data.microbiomedata.org/1777_95829/img_annotation/Ga0482155_functional_annotation.gff", 
+    "md5_checksum": "2fa5357b6e025470478224cc8c4d8443", 
+    "file_size_bytes": 2982414, 
+    "id": "nmdc:2fa5357b6e025470478224cc8c4d8443", 
+    "name": "gold:Gp0119860_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119860", 
+    "url": "https://data.microbiomedata.org/1777_95829/img_annotation/Ga0482155_proteins.faa", 
+    "md5_checksum": "613152955d79f4344828738fb898d679", 
+    "file_size_bytes": 3887828, 
+    "id": "nmdc:613152955d79f4344828738fb898d679", 
+    "name": "gold:Gp0119860_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119860", 
+    "url": "https://data.microbiomedata.org/1777_95829/img_annotation/Ga0482155_structural_annotation.gff", 
+    "md5_checksum": "959ef4ff2d105052b094138aa09b5c94", 
+    "file_size_bytes": 1473538, 
+    "id": "nmdc:959ef4ff2d105052b094138aa09b5c94", 
+    "name": "gold:Gp0119860_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119861", 
+    "url": "https://data.microbiomedata.org/1777_95830/img_annotation/Ga0482154_ec.tsv", 
+    "md5_checksum": "066d13964ce47a41a1e2ef7a5b19cb59", 
+    "file_size_bytes": 177845, 
+    "id": "nmdc:066d13964ce47a41a1e2ef7a5b19cb59", 
+    "name": "gold:Gp0119861_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119861", 
+    "url": "https://data.microbiomedata.org/1777_95830/img_annotation/Ga0482154_ko.tsv", 
+    "md5_checksum": "218b0daa573a8a7f5fc31d6cfe1edad5", 
+    "file_size_bytes": 298834, 
+    "id": "nmdc:218b0daa573a8a7f5fc31d6cfe1edad5", 
+    "name": "gold:Gp0119861_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119861", 
+    "url": "https://data.microbiomedata.org/1777_95830/img_annotation/Ga0482154_functional_annotation.gff", 
+    "md5_checksum": "4f13ca8028e6581e0510d8667456bf28", 
+    "file_size_bytes": 2332956, 
+    "id": "nmdc:4f13ca8028e6581e0510d8667456bf28", 
+    "name": "gold:Gp0119861_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119861", 
+    "url": "https://data.microbiomedata.org/1777_95830/img_annotation/Ga0482154_proteins.faa", 
+    "md5_checksum": "1712f2bb1fa749515ce0bf2b34f8b559", 
+    "file_size_bytes": 3006617, 
+    "id": "nmdc:1712f2bb1fa749515ce0bf2b34f8b559", 
+    "name": "gold:Gp0119861_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119861", 
+    "url": "https://data.microbiomedata.org/1777_95830/img_annotation/Ga0482154_structural_annotation.gff", 
+    "md5_checksum": "0f06cb228b08e2aee24c65444d0bfc21", 
+    "file_size_bytes": 1165986, 
+    "id": "nmdc:0f06cb228b08e2aee24c65444d0bfc21", 
+    "name": "gold:Gp0119861_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119862", 
+    "url": "https://data.microbiomedata.org/1777_95831/img_annotation/Ga0482153_ec.tsv", 
+    "md5_checksum": "ceb802e43562a90b5dc028d818a8f56d", 
+    "file_size_bytes": 296440, 
+    "id": "nmdc:ceb802e43562a90b5dc028d818a8f56d", 
+    "name": "gold:Gp0119862_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119862", 
+    "url": "https://data.microbiomedata.org/1777_95831/img_annotation/Ga0482153_ko.tsv", 
+    "md5_checksum": "9ebfce5805ecaeb07521c28690fa810c", 
+    "file_size_bytes": 504260, 
+    "id": "nmdc:9ebfce5805ecaeb07521c28690fa810c", 
+    "name": "gold:Gp0119862_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119862", 
+    "url": "https://data.microbiomedata.org/1777_95831/img_annotation/Ga0482153_functional_annotation.gff", 
+    "md5_checksum": "895b148dc332f979f35fae25156762d8", 
+    "file_size_bytes": 3521835, 
+    "id": "nmdc:895b148dc332f979f35fae25156762d8", 
+    "name": "gold:Gp0119862_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119862", 
+    "url": "https://data.microbiomedata.org/1777_95831/img_annotation/Ga0482153_proteins.faa", 
+    "md5_checksum": "19e4e0238ac9c1d07646431ee62fa2d9", 
+    "file_size_bytes": 4254600, 
+    "id": "nmdc:19e4e0238ac9c1d07646431ee62fa2d9", 
+    "name": "gold:Gp0119862_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119862", 
+    "url": "https://data.microbiomedata.org/1777_95831/img_annotation/Ga0482153_structural_annotation.gff", 
+    "md5_checksum": "d8e967e38a491678164ab203551aad61", 
+    "file_size_bytes": 1734091, 
+    "id": "nmdc:d8e967e38a491678164ab203551aad61", 
+    "name": "gold:Gp0119862_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119863", 
+    "url": "https://data.microbiomedata.org/1777_95832/img_annotation/Ga0482152_ec.tsv", 
+    "md5_checksum": "091275dd5ad1358b576671f22c2f8157", 
+    "file_size_bytes": 177701, 
+    "id": "nmdc:091275dd5ad1358b576671f22c2f8157", 
+    "name": "gold:Gp0119863_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119863", 
+    "url": "https://data.microbiomedata.org/1777_95832/img_annotation/Ga0482152_ko.tsv", 
+    "md5_checksum": "2318ee29172751d9f66edc54c7a456fa", 
+    "file_size_bytes": 300443, 
+    "id": "nmdc:2318ee29172751d9f66edc54c7a456fa", 
+    "name": "gold:Gp0119863_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119863", 
+    "url": "https://data.microbiomedata.org/1777_95832/img_annotation/Ga0482152_functional_annotation.gff", 
+    "md5_checksum": "f5a9c910bcb6cbec92291db526caa1db", 
+    "file_size_bytes": 2310088, 
+    "id": "nmdc:f5a9c910bcb6cbec92291db526caa1db", 
+    "name": "gold:Gp0119863_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119863", 
+    "url": "https://data.microbiomedata.org/1777_95832/img_annotation/Ga0482152_proteins.faa", 
+    "md5_checksum": "8be139ccce758a8845092122546ff2b3", 
+    "file_size_bytes": 2820296, 
+    "id": "nmdc:8be139ccce758a8845092122546ff2b3", 
+    "name": "gold:Gp0119863_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119863", 
+    "url": "https://data.microbiomedata.org/1777_95832/img_annotation/Ga0482152_structural_annotation.gff", 
+    "md5_checksum": "46cf62901adcbcb2ca2c890b6dc8e6bd", 
+    "file_size_bytes": 1166967, 
+    "id": "nmdc:46cf62901adcbcb2ca2c890b6dc8e6bd", 
+    "name": "gold:Gp0119863_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119864", 
+    "url": "https://data.microbiomedata.org/1777_95833/img_annotation/Ga0482151_ec.tsv", 
+    "md5_checksum": "cc49ea1669ce6a40e73b17880ebdf36e", 
+    "file_size_bytes": 10141846, 
+    "id": "nmdc:cc49ea1669ce6a40e73b17880ebdf36e", 
+    "name": "gold:Gp0119864_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119864", 
+    "url": "https://data.microbiomedata.org/1777_95833/img_annotation/Ga0482151_ko.tsv", 
+    "md5_checksum": "30dc605e7458353cd12e0700042f8b23", 
+    "file_size_bytes": 14137223, 
+    "id": "nmdc:30dc605e7458353cd12e0700042f8b23", 
+    "name": "gold:Gp0119864_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119864", 
+    "url": "https://data.microbiomedata.org/1777_95833/img_annotation/Ga0482151_functional_annotation.gff", 
+    "md5_checksum": "7ae6e443b360f01d0655aa6066e06c87", 
+    "file_size_bytes": 106069049, 
+    "id": "nmdc:7ae6e443b360f01d0655aa6066e06c87", 
+    "name": "gold:Gp0119864_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119864", 
+    "url": "https://data.microbiomedata.org/1777_95833/img_annotation/Ga0482151_proteins.faa", 
+    "md5_checksum": "b803f40f00f0c9988dd5968acd4821cb", 
+    "file_size_bytes": 103678151, 
+    "id": "nmdc:b803f40f00f0c9988dd5968acd4821cb", 
+    "name": "gold:Gp0119864_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119864", 
+    "url": "https://data.microbiomedata.org/1777_95833/img_annotation/Ga0482151_structural_annotation.gff", 
+    "md5_checksum": "3695d84852c6345c02f5f1c3e3f3a423", 
+    "file_size_bytes": 55579513, 
+    "id": "nmdc:3695d84852c6345c02f5f1c3e3f3a423", 
+    "name": "gold:Gp0119864_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119865", 
+    "url": "https://data.microbiomedata.org/1777_95834/img_annotation/Ga0482150_ec.tsv", 
+    "md5_checksum": "e34ef5954fd12e5fdab0bae08414b001", 
+    "file_size_bytes": 17971912, 
+    "id": "nmdc:e34ef5954fd12e5fdab0bae08414b001", 
+    "name": "gold:Gp0119865_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119865", 
+    "url": "https://data.microbiomedata.org/1777_95834/img_annotation/Ga0482150_ko.tsv", 
+    "md5_checksum": "a58d0ad82bcd82747443a05133e86d4a", 
+    "file_size_bytes": 25071575, 
+    "id": "nmdc:a58d0ad82bcd82747443a05133e86d4a", 
+    "name": "gold:Gp0119865_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119865", 
+    "url": "https://data.microbiomedata.org/1777_95834/img_annotation/Ga0482150_functional_annotation.gff", 
+    "md5_checksum": "1f5ea69be09b6f086c09af241d6b9df5", 
+    "file_size_bytes": 196986067, 
+    "id": "nmdc:1f5ea69be09b6f086c09af241d6b9df5", 
+    "name": "gold:Gp0119865_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119865", 
+    "url": "https://data.microbiomedata.org/1777_95834/img_annotation/Ga0482150_proteins.faa", 
+    "md5_checksum": "73e37fa7c4626d47580d5705cb656383", 
+    "file_size_bytes": 208445297, 
+    "id": "nmdc:73e37fa7c4626d47580d5705cb656383", 
+    "name": "gold:Gp0119865_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119865", 
+    "url": "https://data.microbiomedata.org/1777_95834/img_annotation/Ga0482150_structural_annotation.gff", 
+    "md5_checksum": "9f23cbec97a89ce503564d05b061f37f", 
+    "file_size_bytes": 103640083, 
+    "id": "nmdc:9f23cbec97a89ce503564d05b061f37f", 
+    "name": "gold:Gp0119865_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119866", 
+    "url": "https://data.microbiomedata.org/1777_95835/img_annotation/Ga0482149_ec.tsv", 
+    "md5_checksum": "9101306c31f4b8c544f1671e66607a87", 
+    "file_size_bytes": 19381369, 
+    "id": "nmdc:9101306c31f4b8c544f1671e66607a87", 
+    "name": "gold:Gp0119866_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119866", 
+    "url": "https://data.microbiomedata.org/1777_95835/img_annotation/Ga0482149_ko.tsv", 
+    "md5_checksum": "4ef712b7b38e384c25a31fc24c39aab9", 
+    "file_size_bytes": 27584557, 
+    "id": "nmdc:4ef712b7b38e384c25a31fc24c39aab9", 
+    "name": "gold:Gp0119866_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119866", 
+    "url": "https://data.microbiomedata.org/1777_95835/img_annotation/Ga0482149_functional_annotation.gff", 
+    "md5_checksum": "e4f33c52b87b07d9f50cda6bf067d710", 
+    "file_size_bytes": 196458330, 
+    "id": "nmdc:e4f33c52b87b07d9f50cda6bf067d710", 
+    "name": "gold:Gp0119866_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119866", 
+    "url": "https://data.microbiomedata.org/1777_95835/img_annotation/Ga0482149_proteins.faa", 
+    "md5_checksum": "2de8312087081f9aeac56c56195a5fc2", 
+    "file_size_bytes": 210198376, 
+    "id": "nmdc:2de8312087081f9aeac56c56195a5fc2", 
+    "name": "gold:Gp0119866_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119866", 
+    "url": "https://data.microbiomedata.org/1777_95835/img_annotation/Ga0482149_structural_annotation.gff", 
+    "md5_checksum": "5d1bb402cf5170de632179f2515a224f", 
+    "file_size_bytes": 101489460, 
+    "id": "nmdc:5d1bb402cf5170de632179f2515a224f", 
+    "name": "gold:Gp0119866_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119867", 
+    "url": "https://data.microbiomedata.org/1777_95836/img_annotation/Ga0482148_ec.tsv", 
+    "md5_checksum": "e1b8a1bb51b7c8421ed748d3da31cab9", 
+    "file_size_bytes": 11037673, 
+    "id": "nmdc:e1b8a1bb51b7c8421ed748d3da31cab9", 
+    "name": "gold:Gp0119867_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119867", 
+    "url": "https://data.microbiomedata.org/1777_95836/img_annotation/Ga0482148_ko.tsv", 
+    "md5_checksum": "e5a23d1c8e78d044bb907acb7490c223", 
+    "file_size_bytes": 15399817, 
+    "id": "nmdc:e5a23d1c8e78d044bb907acb7490c223", 
+    "name": "gold:Gp0119867_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119867", 
+    "url": "https://data.microbiomedata.org/1777_95836/img_annotation/Ga0482148_functional_annotation.gff", 
+    "md5_checksum": "a4403a73bfd1f57ce219127cd1ebed51", 
+    "file_size_bytes": 109770879, 
+    "id": "nmdc:a4403a73bfd1f57ce219127cd1ebed51", 
+    "name": "gold:Gp0119867_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119867", 
+    "url": "https://data.microbiomedata.org/1777_95836/img_annotation/Ga0482148_proteins.faa", 
+    "md5_checksum": "b20ef196169b86e1498e45194adeff8b", 
+    "file_size_bytes": 115767506, 
+    "id": "nmdc:b20ef196169b86e1498e45194adeff8b", 
+    "name": "gold:Gp0119867_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119867", 
+    "url": "https://data.microbiomedata.org/1777_95836/img_annotation/Ga0482148_structural_annotation.gff", 
+    "md5_checksum": "fd11757a61a2400b5ed8077c62cc97b9", 
+    "file_size_bytes": 56619407, 
+    "id": "nmdc:fd11757a61a2400b5ed8077c62cc97b9", 
+    "name": "gold:Gp0119867_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119868", 
+    "url": "https://data.microbiomedata.org/1777_95837/img_annotation/Ga0482147_ec.tsv", 
+    "md5_checksum": "0289e4fda11b48fb48c641c8e309b3ed", 
+    "file_size_bytes": 33681206, 
+    "id": "nmdc:0289e4fda11b48fb48c641c8e309b3ed", 
+    "name": "gold:Gp0119868_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119868", 
+    "url": "https://data.microbiomedata.org/1777_95837/img_annotation/Ga0482147_ko.tsv", 
+    "md5_checksum": "df46e32e073a15273bb1f709b15abcd3", 
+    "file_size_bytes": 52126454, 
+    "id": "nmdc:df46e32e073a15273bb1f709b15abcd3", 
+    "name": "gold:Gp0119868_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119868", 
+    "url": "https://data.microbiomedata.org/1777_95837/img_annotation/Ga0482147_functional_annotation.gff", 
+    "md5_checksum": "ff55ba482b074f7f3d56c64da1b3c9c8", 
+    "file_size_bytes": 426351388, 
+    "id": "nmdc:ff55ba482b074f7f3d56c64da1b3c9c8", 
+    "name": "gold:Gp0119868_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119868", 
+    "url": "https://data.microbiomedata.org/1777_95837/img_annotation/Ga0482147_proteins.faa", 
+    "md5_checksum": "3c788da6e9004cd3ec276d5e44b19548", 
+    "file_size_bytes": 410939507, 
+    "id": "nmdc:3c788da6e9004cd3ec276d5e44b19548", 
+    "name": "gold:Gp0119868_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119868", 
+    "url": "https://data.microbiomedata.org/1777_95837/img_annotation/Ga0482147_structural_annotation.gff", 
+    "md5_checksum": "804bc97cd8e16289290024ea3a7edbde", 
+    "file_size_bytes": 227076495, 
+    "id": "nmdc:804bc97cd8e16289290024ea3a7edbde", 
+    "name": "gold:Gp0119868_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119869", 
+    "url": "https://data.microbiomedata.org/1777_95838/img_annotation/Ga0480975_ec.tsv", 
+    "md5_checksum": "aa524a698ead96378589ebfec51375f4", 
+    "file_size_bytes": 81513, 
+    "id": "nmdc:aa524a698ead96378589ebfec51375f4", 
+    "name": "gold:Gp0119869_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119869", 
+    "url": "https://data.microbiomedata.org/1777_95838/img_annotation/Ga0480975_ko.tsv", 
+    "md5_checksum": "475a785b8c7e1de1e88d36b2863ad1d8", 
+    "file_size_bytes": 138777, 
+    "id": "nmdc:475a785b8c7e1de1e88d36b2863ad1d8", 
+    "name": "gold:Gp0119869_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119869", 
+    "url": "https://data.microbiomedata.org/1777_95838/img_annotation/Ga0480975_functional_annotation.gff", 
+    "md5_checksum": "ec5a78019044659ab89e4703a2ab57ff", 
+    "file_size_bytes": 950888, 
+    "id": "nmdc:ec5a78019044659ab89e4703a2ab57ff", 
+    "name": "gold:Gp0119869_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119869", 
+    "url": "https://data.microbiomedata.org/1777_95838/img_annotation/Ga0480975_proteins.faa", 
+    "md5_checksum": "c46f4c6ee971aff627dcbfc8f1e3a9e8", 
+    "file_size_bytes": 1249811, 
+    "id": "nmdc:c46f4c6ee971aff627dcbfc8f1e3a9e8", 
+    "name": "gold:Gp0119869_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119869", 
+    "url": "https://data.microbiomedata.org/1777_95838/img_annotation/Ga0480975_structural_annotation.gff", 
+    "md5_checksum": "431354e60f7a35b67c2f7ec52b955808", 
+    "file_size_bytes": 454345, 
+    "id": "nmdc:431354e60f7a35b67c2f7ec52b955808", 
+    "name": "gold:Gp0119869_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119870", 
+    "url": "https://data.microbiomedata.org/1777_96349/img_annotation/Ga0482146_ec.tsv", 
+    "md5_checksum": "9b89126b81c06ae693353614f72344cb", 
+    "file_size_bytes": 10234748, 
+    "id": "nmdc:9b89126b81c06ae693353614f72344cb", 
+    "name": "gold:Gp0119870_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119870", 
+    "url": "https://data.microbiomedata.org/1777_96349/img_annotation/Ga0482146_ko.tsv", 
+    "md5_checksum": "ba17d066f634e0bcc16fbcc7f1ff55f0", 
+    "file_size_bytes": 16343106, 
+    "id": "nmdc:ba17d066f634e0bcc16fbcc7f1ff55f0", 
+    "name": "gold:Gp0119870_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119870", 
+    "url": "https://data.microbiomedata.org/1777_96349/img_annotation/Ga0482146_functional_annotation.gff", 
+    "md5_checksum": "56c01b4ba33b765ad4a478d662a11e75", 
+    "file_size_bytes": 130524524, 
+    "id": "nmdc:56c01b4ba33b765ad4a478d662a11e75", 
+    "name": "gold:Gp0119870_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119870", 
+    "url": "https://data.microbiomedata.org/1777_96349/img_annotation/Ga0482146_proteins.faa", 
+    "md5_checksum": "977d1fc2445d1aecd5f30e0197535af9", 
+    "file_size_bytes": 161126962, 
+    "id": "nmdc:977d1fc2445d1aecd5f30e0197535af9", 
+    "name": "gold:Gp0119870_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119870", 
+    "url": "https://data.microbiomedata.org/1777_96349/img_annotation/Ga0482146_structural_annotation.gff", 
+    "md5_checksum": "4b204c8e49c59d862209579b79c44545", 
+    "file_size_bytes": 67534206, 
+    "id": "nmdc:4b204c8e49c59d862209579b79c44545", 
+    "name": "gold:Gp0119870_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0119871", 
+    "url": "https://data.microbiomedata.org/1777_96350/img_annotation/Ga0482145_ec.tsv", 
+    "md5_checksum": "0c72d3d72c8f29761c48d2844cbbd858", 
+    "file_size_bytes": 11454765, 
+    "id": "nmdc:0c72d3d72c8f29761c48d2844cbbd858", 
+    "name": "gold:Gp0119871_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0119871", 
+    "url": "https://data.microbiomedata.org/1777_96350/img_annotation/Ga0482145_ko.tsv", 
+    "md5_checksum": "cf3c06ff9bb95e6e76b26bdd29add799", 
+    "file_size_bytes": 17713604, 
+    "id": "nmdc:cf3c06ff9bb95e6e76b26bdd29add799", 
+    "name": "gold:Gp0119871_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0119871", 
+    "url": "https://data.microbiomedata.org/1777_96350/img_annotation/Ga0482145_functional_annotation.gff", 
+    "md5_checksum": "c2b7fc5a3e992bb271559774a779c890", 
+    "file_size_bytes": 142108937, 
+    "id": "nmdc:c2b7fc5a3e992bb271559774a779c890", 
+    "name": "gold:Gp0119871_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0119871", 
+    "url": "https://data.microbiomedata.org/1777_96350/img_annotation/Ga0482145_proteins.faa", 
+    "md5_checksum": "8c6e1665a12e9478f7f13b9177b08083", 
+    "file_size_bytes": 159772803, 
+    "id": "nmdc:8c6e1665a12e9478f7f13b9177b08083", 
+    "name": "gold:Gp0119871_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0119871", 
+    "url": "https://data.microbiomedata.org/1777_96350/img_annotation/Ga0482145_structural_annotation.gff", 
+    "md5_checksum": "b2f6e385af8cbe49df3044d523da5c82", 
+    "file_size_bytes": 73533075, 
+    "id": "nmdc:b2f6e385af8cbe49df3044d523da5c82", 
+    "name": "gold:Gp0119871_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127623", 
+    "url": "https://data.microbiomedata.org/1781_100325/img_annotation/Ga0482247_ec.tsv", 
+    "md5_checksum": "d6afa54f891852b3a5befc294ce84489", 
+    "file_size_bytes": 2583122, 
+    "id": "nmdc:d6afa54f891852b3a5befc294ce84489", 
+    "name": "gold:Gp0127623_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127623", 
+    "url": "https://data.microbiomedata.org/1781_100325/img_annotation/Ga0482247_ko.tsv", 
+    "md5_checksum": "e15c4db1e4e26208b302ecb9bc2c094c", 
+    "file_size_bytes": 3771658, 
+    "id": "nmdc:e15c4db1e4e26208b302ecb9bc2c094c", 
+    "name": "gold:Gp0127623_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127623", 
+    "url": "https://data.microbiomedata.org/1781_100325/img_annotation/Ga0482247_functional_annotation.gff", 
+    "md5_checksum": "3acc269b9e2b5e97ffcc3c1a0d85381c", 
+    "file_size_bytes": 34441118, 
+    "id": "nmdc:3acc269b9e2b5e97ffcc3c1a0d85381c", 
+    "name": "gold:Gp0127623_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127623", 
+    "url": "https://data.microbiomedata.org/1781_100325/img_annotation/Ga0482247_proteins.faa", 
+    "md5_checksum": "be62e3b68916c8077955d0b3d3aaf5aa", 
+    "file_size_bytes": 30576166, 
+    "id": "nmdc:be62e3b68916c8077955d0b3d3aaf5aa", 
+    "name": "gold:Gp0127623_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127623", 
+    "url": "https://data.microbiomedata.org/1781_100325/img_annotation/Ga0482247_structural_annotation.gff", 
+    "md5_checksum": "feb21db71dc44afceeb88bb725315b42", 
+    "file_size_bytes": 18331505, 
+    "id": "nmdc:feb21db71dc44afceeb88bb725315b42", 
+    "name": "gold:Gp0127623_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127624", 
+    "url": "https://data.microbiomedata.org/1781_100326/img_annotation/Ga0482246_ec.tsv", 
+    "md5_checksum": "73ebb84a8744552c890ad2508e313972", 
+    "file_size_bytes": 4198240, 
+    "id": "nmdc:73ebb84a8744552c890ad2508e313972", 
+    "name": "gold:Gp0127624_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127624", 
+    "url": "https://data.microbiomedata.org/1781_100326/img_annotation/Ga0482246_ko.tsv", 
+    "md5_checksum": "89a4bb36ef225146a2ba0daaaea512fd", 
+    "file_size_bytes": 6278897, 
+    "id": "nmdc:89a4bb36ef225146a2ba0daaaea512fd", 
+    "name": "gold:Gp0127624_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127624", 
+    "url": "https://data.microbiomedata.org/1781_100326/img_annotation/Ga0482246_functional_annotation.gff", 
+    "md5_checksum": "6bcdfc58ee6b4eb5ae022c71636a88b4", 
+    "file_size_bytes": 58028117, 
+    "id": "nmdc:6bcdfc58ee6b4eb5ae022c71636a88b4", 
+    "name": "gold:Gp0127624_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127624", 
+    "url": "https://data.microbiomedata.org/1781_100326/img_annotation/Ga0482246_proteins.faa", 
+    "md5_checksum": "075262a23b12fd4da073a973a5b6cf15", 
+    "file_size_bytes": 52612935, 
+    "id": "nmdc:075262a23b12fd4da073a973a5b6cf15", 
+    "name": "gold:Gp0127624_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127624", 
+    "url": "https://data.microbiomedata.org/1781_100326/img_annotation/Ga0482246_structural_annotation.gff", 
+    "md5_checksum": "3fb3966095303ea8aa7f27bff3e9db50", 
+    "file_size_bytes": 30763063, 
+    "id": "nmdc:3fb3966095303ea8aa7f27bff3e9db50", 
+    "name": "gold:Gp0127624_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127625", 
+    "url": "https://data.microbiomedata.org/1781_100327/img_annotation/Ga0482245_ec.tsv", 
+    "md5_checksum": "16eb9d7ffc8dbf8872cbdb9b7f0a1c82", 
+    "file_size_bytes": 6922056, 
+    "id": "nmdc:16eb9d7ffc8dbf8872cbdb9b7f0a1c82", 
+    "name": "gold:Gp0127625_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127625", 
+    "url": "https://data.microbiomedata.org/1781_100327/img_annotation/Ga0482245_ko.tsv", 
+    "md5_checksum": "18dd16caf7af261c4d647da91a6f526a", 
+    "file_size_bytes": 10382404, 
+    "id": "nmdc:18dd16caf7af261c4d647da91a6f526a", 
+    "name": "gold:Gp0127625_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127625", 
+    "url": "https://data.microbiomedata.org/1781_100327/img_annotation/Ga0482245_functional_annotation.gff", 
+    "md5_checksum": "3b039b9d5a75b97a67edf5d50b34d9f0", 
+    "file_size_bytes": 96600653, 
+    "id": "nmdc:3b039b9d5a75b97a67edf5d50b34d9f0", 
+    "name": "gold:Gp0127625_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127625", 
+    "url": "https://data.microbiomedata.org/1781_100327/img_annotation/Ga0482245_proteins.faa", 
+    "md5_checksum": "c6fb34fc2da63a5cc46522279e768db9", 
+    "file_size_bytes": 91272582, 
+    "id": "nmdc:c6fb34fc2da63a5cc46522279e768db9", 
+    "name": "gold:Gp0127625_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127625", 
+    "url": "https://data.microbiomedata.org/1781_100327/img_annotation/Ga0482245_structural_annotation.gff", 
+    "md5_checksum": "bf23db2dda841d77cf51b7c9120ba503", 
+    "file_size_bytes": 51025175, 
+    "id": "nmdc:bf23db2dda841d77cf51b7c9120ba503", 
+    "name": "gold:Gp0127625_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127626", 
+    "url": "https://data.microbiomedata.org/1781_100328/img_annotation/Ga0482244_ec.tsv", 
+    "md5_checksum": "dde9a2b70a0552a8d6f7cda7f4862aa9", 
+    "file_size_bytes": 2233232, 
+    "id": "nmdc:dde9a2b70a0552a8d6f7cda7f4862aa9", 
+    "name": "gold:Gp0127626_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127626", 
+    "url": "https://data.microbiomedata.org/1781_100328/img_annotation/Ga0482244_ko.tsv", 
+    "md5_checksum": "1f45d481e2882a15e7d060e47cbbfda3", 
+    "file_size_bytes": 3340571, 
+    "id": "nmdc:1f45d481e2882a15e7d060e47cbbfda3", 
+    "name": "gold:Gp0127626_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127626", 
+    "url": "https://data.microbiomedata.org/1781_100328/img_annotation/Ga0482244_functional_annotation.gff", 
+    "md5_checksum": "8e19f17a8fd0747410b68d804b87139d", 
+    "file_size_bytes": 30426724, 
+    "id": "nmdc:8e19f17a8fd0747410b68d804b87139d", 
+    "name": "gold:Gp0127626_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127626", 
+    "url": "https://data.microbiomedata.org/1781_100328/img_annotation/Ga0482244_proteins.faa", 
+    "md5_checksum": "11741b35b589852f2b652d1f73afb663", 
+    "file_size_bytes": 26706052, 
+    "id": "nmdc:11741b35b589852f2b652d1f73afb663", 
+    "name": "gold:Gp0127626_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127626", 
+    "url": "https://data.microbiomedata.org/1781_100328/img_annotation/Ga0482244_structural_annotation.gff", 
+    "md5_checksum": "f1b6a4b001b67ec72eb5b5411e1321c9", 
+    "file_size_bytes": 16237998, 
+    "id": "nmdc:f1b6a4b001b67ec72eb5b5411e1321c9", 
+    "name": "gold:Gp0127626_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127627", 
+    "url": "https://data.microbiomedata.org/1781_100329/img_annotation/Ga0482243_ec.tsv", 
+    "md5_checksum": "4c97ec34649fc995f167408bd39c9998", 
+    "file_size_bytes": 1017343, 
+    "id": "nmdc:4c97ec34649fc995f167408bd39c9998", 
+    "name": "gold:Gp0127627_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127627", 
+    "url": "https://data.microbiomedata.org/1781_100329/img_annotation/Ga0482243_ko.tsv", 
+    "md5_checksum": "874ae45fc2a007a7d5f9ff964fa8117a", 
+    "file_size_bytes": 1531065, 
+    "id": "nmdc:874ae45fc2a007a7d5f9ff964fa8117a", 
+    "name": "gold:Gp0127627_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127627", 
+    "url": "https://data.microbiomedata.org/1781_100329/img_annotation/Ga0482243_functional_annotation.gff", 
+    "md5_checksum": "6c96999ab72498624aae8bb9b0bfbc66", 
+    "file_size_bytes": 13569403, 
+    "id": "nmdc:6c96999ab72498624aae8bb9b0bfbc66", 
+    "name": "gold:Gp0127627_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127627", 
+    "url": "https://data.microbiomedata.org/1781_100329/img_annotation/Ga0482243_proteins.faa", 
+    "md5_checksum": "fec0b3842897bbce9166a628c4c2d7a0", 
+    "file_size_bytes": 11438905, 
+    "id": "nmdc:fec0b3842897bbce9166a628c4c2d7a0", 
+    "name": "gold:Gp0127627_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127627", 
+    "url": "https://data.microbiomedata.org/1781_100329/img_annotation/Ga0482243_structural_annotation.gff", 
+    "md5_checksum": "48ab9737528d088ffde37b733e3f728f", 
+    "file_size_bytes": 7287620, 
+    "id": "nmdc:48ab9737528d088ffde37b733e3f728f", 
+    "name": "gold:Gp0127627_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127628", 
+    "url": "https://data.microbiomedata.org/1781_100330/img_annotation/Ga0482242_ec.tsv", 
+    "md5_checksum": "760a1e1bc5aac21dd0b96098c72133ff", 
+    "file_size_bytes": 3402591, 
+    "id": "nmdc:760a1e1bc5aac21dd0b96098c72133ff", 
+    "name": "gold:Gp0127628_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127628", 
+    "url": "https://data.microbiomedata.org/1781_100330/img_annotation/Ga0482242_ko.tsv", 
+    "md5_checksum": "69da278e8966a688cafb7bb2c8f2e4d1", 
+    "file_size_bytes": 5115159, 
+    "id": "nmdc:69da278e8966a688cafb7bb2c8f2e4d1", 
+    "name": "gold:Gp0127628_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127628", 
+    "url": "https://data.microbiomedata.org/1781_100330/img_annotation/Ga0482242_functional_annotation.gff", 
+    "md5_checksum": "b73bf45facd909d89bfab76dee85a2cc", 
+    "file_size_bytes": 46270912, 
+    "id": "nmdc:b73bf45facd909d89bfab76dee85a2cc", 
+    "name": "gold:Gp0127628_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127628", 
+    "url": "https://data.microbiomedata.org/1781_100330/img_annotation/Ga0482242_proteins.faa", 
+    "md5_checksum": "ec55b61e1204cde7fe61841179b88b53", 
+    "file_size_bytes": 41298193, 
+    "id": "nmdc:ec55b61e1204cde7fe61841179b88b53", 
+    "name": "gold:Gp0127628_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127628", 
+    "url": "https://data.microbiomedata.org/1781_100330/img_annotation/Ga0482242_structural_annotation.gff", 
+    "md5_checksum": "bd55dfd59ed0aa7ea685734c5b7ecbab", 
+    "file_size_bytes": 24598711, 
+    "id": "nmdc:bd55dfd59ed0aa7ea685734c5b7ecbab", 
+    "name": "gold:Gp0127628_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127629", 
+    "url": "https://data.microbiomedata.org/1781_100331/img_annotation/Ga0482241_ec.tsv", 
+    "md5_checksum": "f9211f36dc6992c2dfecd160987434c7", 
+    "file_size_bytes": 4780617, 
+    "id": "nmdc:f9211f36dc6992c2dfecd160987434c7", 
+    "name": "gold:Gp0127629_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127629", 
+    "url": "https://data.microbiomedata.org/1781_100331/img_annotation/Ga0482241_ko.tsv", 
+    "md5_checksum": "37fb326b25c1ae3caebddf668feadd76", 
+    "file_size_bytes": 7099533, 
+    "id": "nmdc:37fb326b25c1ae3caebddf668feadd76", 
+    "name": "gold:Gp0127629_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127629", 
+    "url": "https://data.microbiomedata.org/1781_100331/img_annotation/Ga0482241_functional_annotation.gff", 
+    "md5_checksum": "75e43708767f06de878e1c2115714e0b", 
+    "file_size_bytes": 64403966, 
+    "id": "nmdc:75e43708767f06de878e1c2115714e0b", 
+    "name": "gold:Gp0127629_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127629", 
+    "url": "https://data.microbiomedata.org/1781_100331/img_annotation/Ga0482241_proteins.faa", 
+    "md5_checksum": "9559ebd9a8921ff8ae9f89c2ffcef6f7", 
+    "file_size_bytes": 59055855, 
+    "id": "nmdc:9559ebd9a8921ff8ae9f89c2ffcef6f7", 
+    "name": "gold:Gp0127629_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127629", 
+    "url": "https://data.microbiomedata.org/1781_100331/img_annotation/Ga0482241_structural_annotation.gff", 
+    "md5_checksum": "9b3fb3e409e3d3128a8a43cc58d32a95", 
+    "file_size_bytes": 34047946, 
+    "id": "nmdc:9b3fb3e409e3d3128a8a43cc58d32a95", 
+    "name": "gold:Gp0127629_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127630", 
+    "url": "https://data.microbiomedata.org/1781_100332/img_annotation/Ga0482240_ec.tsv", 
+    "md5_checksum": "81ab86211731bc0547d3e8f8786c3e8b", 
+    "file_size_bytes": 2634654, 
+    "id": "nmdc:81ab86211731bc0547d3e8f8786c3e8b", 
+    "name": "gold:Gp0127630_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127630", 
+    "url": "https://data.microbiomedata.org/1781_100332/img_annotation/Ga0482240_ko.tsv", 
+    "md5_checksum": "c6b5f388349af0214d65d1357026c7ee", 
+    "file_size_bytes": 3943156, 
+    "id": "nmdc:c6b5f388349af0214d65d1357026c7ee", 
+    "name": "gold:Gp0127630_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127630", 
+    "url": "https://data.microbiomedata.org/1781_100332/img_annotation/Ga0482240_functional_annotation.gff", 
+    "md5_checksum": "070f0952308650d35ae05c4fed188677", 
+    "file_size_bytes": 36758620, 
+    "id": "nmdc:070f0952308650d35ae05c4fed188677", 
+    "name": "gold:Gp0127630_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127630", 
+    "url": "https://data.microbiomedata.org/1781_100332/img_annotation/Ga0482240_proteins.faa", 
+    "md5_checksum": "6bca5ad106b3519416205a82d3a14b16", 
+    "file_size_bytes": 32472699, 
+    "id": "nmdc:6bca5ad106b3519416205a82d3a14b16", 
+    "name": "gold:Gp0127630_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127630", 
+    "url": "https://data.microbiomedata.org/1781_100332/img_annotation/Ga0482240_structural_annotation.gff", 
+    "md5_checksum": "f921989651475b06052058126db54de9", 
+    "file_size_bytes": 19630340, 
+    "id": "nmdc:f921989651475b06052058126db54de9", 
+    "name": "gold:Gp0127630_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127631", 
+    "url": "https://data.microbiomedata.org/1781_100333/img_annotation/Ga0482239_ec.tsv", 
+    "md5_checksum": "ee276fe3eb490475ad3d7280a8c67464", 
+    "file_size_bytes": 5128997, 
+    "id": "nmdc:ee276fe3eb490475ad3d7280a8c67464", 
+    "name": "gold:Gp0127631_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127631", 
+    "url": "https://data.microbiomedata.org/1781_100333/img_annotation/Ga0482239_ko.tsv", 
+    "md5_checksum": "e2ef79ef2b6669d93af5e90ba2c58fcf", 
+    "file_size_bytes": 7765858, 
+    "id": "nmdc:e2ef79ef2b6669d93af5e90ba2c58fcf", 
+    "name": "gold:Gp0127631_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127631", 
+    "url": "https://data.microbiomedata.org/1781_100333/img_annotation/Ga0482239_functional_annotation.gff", 
+    "md5_checksum": "5723e7023b0e3994e92c7c5e72aa34ec", 
+    "file_size_bytes": 74436702, 
+    "id": "nmdc:5723e7023b0e3994e92c7c5e72aa34ec", 
+    "name": "gold:Gp0127631_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127631", 
+    "url": "https://data.microbiomedata.org/1781_100333/img_annotation/Ga0482239_proteins.faa", 
+    "md5_checksum": "04c97ac7af06bf37da8f1ffe827e454d", 
+    "file_size_bytes": 69257479, 
+    "id": "nmdc:04c97ac7af06bf37da8f1ffe827e454d", 
+    "name": "gold:Gp0127631_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127631", 
+    "url": "https://data.microbiomedata.org/1781_100333/img_annotation/Ga0482239_structural_annotation.gff", 
+    "md5_checksum": "d57f28027b2d6f82b96f5413bf8c9a59", 
+    "file_size_bytes": 39672117, 
+    "id": "nmdc:d57f28027b2d6f82b96f5413bf8c9a59", 
+    "name": "gold:Gp0127631_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127632", 
+    "url": "https://data.microbiomedata.org/1781_100334/img_annotation/Ga0482238_ec.tsv", 
+    "md5_checksum": "b8d886e71031cbe4fb1284f479348740", 
+    "file_size_bytes": 2745047, 
+    "id": "nmdc:b8d886e71031cbe4fb1284f479348740", 
+    "name": "gold:Gp0127632_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127632", 
+    "url": "https://data.microbiomedata.org/1781_100334/img_annotation/Ga0482238_ko.tsv", 
+    "md5_checksum": "aeafeb18adb193b1a3c5c3c2ff9a912e", 
+    "file_size_bytes": 4100607, 
+    "id": "nmdc:aeafeb18adb193b1a3c5c3c2ff9a912e", 
+    "name": "gold:Gp0127632_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127632", 
+    "url": "https://data.microbiomedata.org/1781_100334/img_annotation/Ga0482238_functional_annotation.gff", 
+    "md5_checksum": "2395040203b3351554a9e3ffb48b0b88", 
+    "file_size_bytes": 38234498, 
+    "id": "nmdc:2395040203b3351554a9e3ffb48b0b88", 
+    "name": "gold:Gp0127632_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127632", 
+    "url": "https://data.microbiomedata.org/1781_100334/img_annotation/Ga0482238_proteins.faa", 
+    "md5_checksum": "a89e8af0fc6daf895e7a87f1ff7087f2", 
+    "file_size_bytes": 33833181, 
+    "id": "nmdc:a89e8af0fc6daf895e7a87f1ff7087f2", 
+    "name": "gold:Gp0127632_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127632", 
+    "url": "https://data.microbiomedata.org/1781_100334/img_annotation/Ga0482238_structural_annotation.gff", 
+    "md5_checksum": "89b895fbf3c13801ddba22ff59bb385a", 
+    "file_size_bytes": 20431199, 
+    "id": "nmdc:89b895fbf3c13801ddba22ff59bb385a", 
+    "name": "gold:Gp0127632_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127633", 
+    "url": "https://data.microbiomedata.org/1781_100335/img_annotation/Ga0482237_ec.tsv", 
+    "md5_checksum": "31e2f5b7b055f2959d50a990ebda7ff6", 
+    "file_size_bytes": 6061258, 
+    "id": "nmdc:31e2f5b7b055f2959d50a990ebda7ff6", 
+    "name": "gold:Gp0127633_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127633", 
+    "url": "https://data.microbiomedata.org/1781_100335/img_annotation/Ga0482237_ko.tsv", 
+    "md5_checksum": "9ef3a52b2d97cc4afb64e37d04e59865", 
+    "file_size_bytes": 9198099, 
+    "id": "nmdc:9ef3a52b2d97cc4afb64e37d04e59865", 
+    "name": "gold:Gp0127633_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127633", 
+    "url": "https://data.microbiomedata.org/1781_100335/img_annotation/Ga0482237_functional_annotation.gff", 
+    "md5_checksum": "740240c975daffee3e63251fc86cfd33", 
+    "file_size_bytes": 86912846, 
+    "id": "nmdc:740240c975daffee3e63251fc86cfd33", 
+    "name": "gold:Gp0127633_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127633", 
+    "url": "https://data.microbiomedata.org/1781_100335/img_annotation/Ga0482237_proteins.faa", 
+    "md5_checksum": "79fd564d59bf9fe4cfb2c771daa84f29", 
+    "file_size_bytes": 81594548, 
+    "id": "nmdc:79fd564d59bf9fe4cfb2c771daa84f29", 
+    "name": "gold:Gp0127633_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127633", 
+    "url": "https://data.microbiomedata.org/1781_100335/img_annotation/Ga0482237_structural_annotation.gff", 
+    "md5_checksum": "b18381667b4e7401e1bb58e8aede5d4a", 
+    "file_size_bytes": 46058587, 
+    "id": "nmdc:b18381667b4e7401e1bb58e8aede5d4a", 
+    "name": "gold:Gp0127633_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127634", 
+    "url": "https://data.microbiomedata.org/1781_100336/img_annotation/Ga0482236_ec.tsv", 
+    "md5_checksum": "01b078b5b9dde5699e9b9ab02af272df", 
+    "file_size_bytes": 3820674, 
+    "id": "nmdc:01b078b5b9dde5699e9b9ab02af272df", 
+    "name": "gold:Gp0127634_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127634", 
+    "url": "https://data.microbiomedata.org/1781_100336/img_annotation/Ga0482236_ko.tsv", 
+    "md5_checksum": "5b2ff10d97d2b516716a67dafb137937", 
+    "file_size_bytes": 5717917, 
+    "id": "nmdc:5b2ff10d97d2b516716a67dafb137937", 
+    "name": "gold:Gp0127634_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127634", 
+    "url": "https://data.microbiomedata.org/1781_100336/img_annotation/Ga0482236_functional_annotation.gff", 
+    "md5_checksum": "803451414e1935d4de9f9911963efe8d", 
+    "file_size_bytes": 52406322, 
+    "id": "nmdc:803451414e1935d4de9f9911963efe8d", 
+    "name": "gold:Gp0127634_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127634", 
+    "url": "https://data.microbiomedata.org/1781_100336/img_annotation/Ga0482236_proteins.faa", 
+    "md5_checksum": "3374b8708ae6b77b16cd01ce4f33ee72", 
+    "file_size_bytes": 47067520, 
+    "id": "nmdc:3374b8708ae6b77b16cd01ce4f33ee72", 
+    "name": "gold:Gp0127634_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127634", 
+    "url": "https://data.microbiomedata.org/1781_100336/img_annotation/Ga0482236_structural_annotation.gff", 
+    "md5_checksum": "1e286398d6b164538bbdefb9cc8a41e9", 
+    "file_size_bytes": 27840147, 
+    "id": "nmdc:1e286398d6b164538bbdefb9cc8a41e9", 
+    "name": "gold:Gp0127634_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127635", 
+    "url": "https://data.microbiomedata.org/1781_100337/img_annotation/Ga0482235_ec.tsv", 
+    "md5_checksum": "9e0a73962f7014df93613b04fae9f8be", 
+    "file_size_bytes": 4603948, 
+    "id": "nmdc:9e0a73962f7014df93613b04fae9f8be", 
+    "name": "gold:Gp0127635_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127635", 
+    "url": "https://data.microbiomedata.org/1781_100337/img_annotation/Ga0482235_ko.tsv", 
+    "md5_checksum": "4cddc89fb8b405210d66b836825c37ee", 
+    "file_size_bytes": 6946175, 
+    "id": "nmdc:4cddc89fb8b405210d66b836825c37ee", 
+    "name": "gold:Gp0127635_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127635", 
+    "url": "https://data.microbiomedata.org/1781_100337/img_annotation/Ga0482235_functional_annotation.gff", 
+    "md5_checksum": "4768d5de701a1ac55ed0c2d57a270dd2", 
+    "file_size_bytes": 64666871, 
+    "id": "nmdc:4768d5de701a1ac55ed0c2d57a270dd2", 
+    "name": "gold:Gp0127635_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127635", 
+    "url": "https://data.microbiomedata.org/1781_100337/img_annotation/Ga0482235_proteins.faa", 
+    "md5_checksum": "b2ee2639269e6d665f772fc8c4e31d07", 
+    "file_size_bytes": 59977896, 
+    "id": "nmdc:b2ee2639269e6d665f772fc8c4e31d07", 
+    "name": "gold:Gp0127635_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127635", 
+    "url": "https://data.microbiomedata.org/1781_100337/img_annotation/Ga0482235_structural_annotation.gff", 
+    "md5_checksum": "e1cd02b3a92223d8e30e8d7c90837d9a", 
+    "file_size_bytes": 34241597, 
+    "id": "nmdc:e1cd02b3a92223d8e30e8d7c90837d9a", 
+    "name": "gold:Gp0127635_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127636", 
+    "url": "https://data.microbiomedata.org/1781_100338/img_annotation/Ga0482234_ec.tsv", 
+    "md5_checksum": "80ec7d76d2509e6eeab61d092808908b", 
+    "file_size_bytes": 1807522, 
+    "id": "nmdc:80ec7d76d2509e6eeab61d092808908b", 
+    "name": "gold:Gp0127636_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127636", 
+    "url": "https://data.microbiomedata.org/1781_100338/img_annotation/Ga0482234_ko.tsv", 
+    "md5_checksum": "d68e6d4245c33a73666148570aac9c10", 
+    "file_size_bytes": 2736440, 
+    "id": "nmdc:d68e6d4245c33a73666148570aac9c10", 
+    "name": "gold:Gp0127636_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127636", 
+    "url": "https://data.microbiomedata.org/1781_100338/img_annotation/Ga0482234_functional_annotation.gff", 
+    "md5_checksum": "31f8346eeca4b929a6c28686bb8b2043", 
+    "file_size_bytes": 25714870, 
+    "id": "nmdc:31f8346eeca4b929a6c28686bb8b2043", 
+    "name": "gold:Gp0127636_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127636", 
+    "url": "https://data.microbiomedata.org/1781_100338/img_annotation/Ga0482234_proteins.faa", 
+    "md5_checksum": "66d9d6751efad0b8019a565488f950a5", 
+    "file_size_bytes": 22123834, 
+    "id": "nmdc:66d9d6751efad0b8019a565488f950a5", 
+    "name": "gold:Gp0127636_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127636", 
+    "url": "https://data.microbiomedata.org/1781_100338/img_annotation/Ga0482234_structural_annotation.gff", 
+    "md5_checksum": "e3b57dff7ca37c0da6b7d4bfb4450d9c", 
+    "file_size_bytes": 13805149, 
+    "id": "nmdc:e3b57dff7ca37c0da6b7d4bfb4450d9c", 
+    "name": "gold:Gp0127636_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127637", 
+    "url": "https://data.microbiomedata.org/1781_100339/img_annotation/Ga0482233_ec.tsv", 
+    "md5_checksum": "1549562abe1044734fab8562585ec161", 
+    "file_size_bytes": 4822891, 
+    "id": "nmdc:1549562abe1044734fab8562585ec161", 
+    "name": "gold:Gp0127637_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127637", 
+    "url": "https://data.microbiomedata.org/1781_100339/img_annotation/Ga0482233_ko.tsv", 
+    "md5_checksum": "ce74f349e03ae28dd49fc5ea4cd1d91d", 
+    "file_size_bytes": 7266783, 
+    "id": "nmdc:ce74f349e03ae28dd49fc5ea4cd1d91d", 
+    "name": "gold:Gp0127637_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127637", 
+    "url": "https://data.microbiomedata.org/1781_100339/img_annotation/Ga0482233_functional_annotation.gff", 
+    "md5_checksum": "74b2fc3dd196a3d615c7d0d478fa2f90", 
+    "file_size_bytes": 67728064, 
+    "id": "nmdc:74b2fc3dd196a3d615c7d0d478fa2f90", 
+    "name": "gold:Gp0127637_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127637", 
+    "url": "https://data.microbiomedata.org/1781_100339/img_annotation/Ga0482233_proteins.faa", 
+    "md5_checksum": "c43a6b5a306a8f14aab780d8f1bf9c41", 
+    "file_size_bytes": 62931098, 
+    "id": "nmdc:c43a6b5a306a8f14aab780d8f1bf9c41", 
+    "name": "gold:Gp0127637_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127637", 
+    "url": "https://data.microbiomedata.org/1781_100339/img_annotation/Ga0482233_structural_annotation.gff", 
+    "md5_checksum": "5f6b287493cde8cf8cb49348a2868aa6", 
+    "file_size_bytes": 35820884, 
+    "id": "nmdc:5f6b287493cde8cf8cb49348a2868aa6", 
+    "name": "gold:Gp0127637_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127638", 
+    "url": "https://data.microbiomedata.org/1781_100340/img_annotation/Ga0482232_ec.tsv", 
+    "md5_checksum": "3bd360103e4e8fc8f89c1df345367776", 
+    "file_size_bytes": 3928927, 
+    "id": "nmdc:3bd360103e4e8fc8f89c1df345367776", 
+    "name": "gold:Gp0127638_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127638", 
+    "url": "https://data.microbiomedata.org/1781_100340/img_annotation/Ga0482232_ko.tsv", 
+    "md5_checksum": "1aba5135d8cddc36da3cd37579be190b", 
+    "file_size_bytes": 5829514, 
+    "id": "nmdc:1aba5135d8cddc36da3cd37579be190b", 
+    "name": "gold:Gp0127638_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127638", 
+    "url": "https://data.microbiomedata.org/1781_100340/img_annotation/Ga0482232_functional_annotation.gff", 
+    "md5_checksum": "3da4d2f1c2db68033fa2264f4db7f459", 
+    "file_size_bytes": 51694976, 
+    "id": "nmdc:3da4d2f1c2db68033fa2264f4db7f459", 
+    "name": "gold:Gp0127638_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127638", 
+    "url": "https://data.microbiomedata.org/1781_100340/img_annotation/Ga0482232_proteins.faa", 
+    "md5_checksum": "17993d4fcfa7be4fd4488804d23b67c6", 
+    "file_size_bytes": 46728415, 
+    "id": "nmdc:17993d4fcfa7be4fd4488804d23b67c6", 
+    "name": "gold:Gp0127638_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127638", 
+    "url": "https://data.microbiomedata.org/1781_100340/img_annotation/Ga0482232_structural_annotation.gff", 
+    "md5_checksum": "2ca3e1a0ba8007e86dedbec47e85adba", 
+    "file_size_bytes": 27252481, 
+    "id": "nmdc:2ca3e1a0ba8007e86dedbec47e85adba", 
+    "name": "gold:Gp0127638_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127639", 
+    "url": "https://data.microbiomedata.org/1781_100341/img_annotation/Ga0482231_ec.tsv", 
+    "md5_checksum": "7e710e983d3a5ffbddc618c5e252e06b", 
+    "file_size_bytes": 5008380, 
+    "id": "nmdc:7e710e983d3a5ffbddc618c5e252e06b", 
+    "name": "gold:Gp0127639_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127639", 
+    "url": "https://data.microbiomedata.org/1781_100341/img_annotation/Ga0482231_ko.tsv", 
+    "md5_checksum": "ccbc768cb20e4c1b25d7627b611eb8dc", 
+    "file_size_bytes": 7538621, 
+    "id": "nmdc:ccbc768cb20e4c1b25d7627b611eb8dc", 
+    "name": "gold:Gp0127639_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127639", 
+    "url": "https://data.microbiomedata.org/1781_100341/img_annotation/Ga0482231_functional_annotation.gff", 
+    "md5_checksum": "ee416a49155f7c07bcb776962708fb04", 
+    "file_size_bytes": 68432516, 
+    "id": "nmdc:ee416a49155f7c07bcb776962708fb04", 
+    "name": "gold:Gp0127639_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127639", 
+    "url": "https://data.microbiomedata.org/1781_100341/img_annotation/Ga0482231_proteins.faa", 
+    "md5_checksum": "fccc8283a46f12babeed0b2c7cc4eebd", 
+    "file_size_bytes": 64225416, 
+    "id": "nmdc:fccc8283a46f12babeed0b2c7cc4eebd", 
+    "name": "gold:Gp0127639_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127639", 
+    "url": "https://data.microbiomedata.org/1781_100341/img_annotation/Ga0482231_structural_annotation.gff", 
+    "md5_checksum": "d0452fefd4ad4f4cd10c974294bf9058", 
+    "file_size_bytes": 36008059, 
+    "id": "nmdc:d0452fefd4ad4f4cd10c974294bf9058", 
+    "name": "gold:Gp0127639_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127640", 
+    "url": "https://data.microbiomedata.org/1781_100342/img_annotation/Ga0482230_ec.tsv", 
+    "md5_checksum": "e90b16891cff9bd5b0034cc6c89f8080", 
+    "file_size_bytes": 2081474, 
+    "id": "nmdc:e90b16891cff9bd5b0034cc6c89f8080", 
+    "name": "gold:Gp0127640_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127640", 
+    "url": "https://data.microbiomedata.org/1781_100342/img_annotation/Ga0482230_ko.tsv", 
+    "md5_checksum": "4950dc66d2b5a3c325454fb106d6b726", 
+    "file_size_bytes": 3144788, 
+    "id": "nmdc:4950dc66d2b5a3c325454fb106d6b726", 
+    "name": "gold:Gp0127640_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127640", 
+    "url": "https://data.microbiomedata.org/1781_100342/img_annotation/Ga0482230_functional_annotation.gff", 
+    "md5_checksum": "86b6734c5eb64c0cae6e95fa7f062123", 
+    "file_size_bytes": 29331739, 
+    "id": "nmdc:86b6734c5eb64c0cae6e95fa7f062123", 
+    "name": "gold:Gp0127640_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127640", 
+    "url": "https://data.microbiomedata.org/1781_100342/img_annotation/Ga0482230_proteins.faa", 
+    "md5_checksum": "1fbb7302a6ad581085d561e9fd3ed802", 
+    "file_size_bytes": 25228822, 
+    "id": "nmdc:1fbb7302a6ad581085d561e9fd3ed802", 
+    "name": "gold:Gp0127640_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127640", 
+    "url": "https://data.microbiomedata.org/1781_100342/img_annotation/Ga0482230_structural_annotation.gff", 
+    "md5_checksum": "812cf8b77747ff65cfd237158535d310", 
+    "file_size_bytes": 15812322, 
+    "id": "nmdc:812cf8b77747ff65cfd237158535d310", 
+    "name": "gold:Gp0127640_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127641", 
+    "url": "https://data.microbiomedata.org/1781_100343/img_annotation/Ga0482229_ec.tsv", 
+    "md5_checksum": "71306193abf043865cafa413b3ca9c1e", 
+    "file_size_bytes": 4161778, 
+    "id": "nmdc:71306193abf043865cafa413b3ca9c1e", 
+    "name": "gold:Gp0127641_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127641", 
+    "url": "https://data.microbiomedata.org/1781_100343/img_annotation/Ga0482229_ko.tsv", 
+    "md5_checksum": "4ec0cbf7d166057c3d2904b2dd2f6b15", 
+    "file_size_bytes": 6291951, 
+    "id": "nmdc:4ec0cbf7d166057c3d2904b2dd2f6b15", 
+    "name": "gold:Gp0127641_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127641", 
+    "url": "https://data.microbiomedata.org/1781_100343/img_annotation/Ga0482229_functional_annotation.gff", 
+    "md5_checksum": "11d4524c896f4fd678ff05a0547b6b52", 
+    "file_size_bytes": 59277496, 
+    "id": "nmdc:11d4524c896f4fd678ff05a0547b6b52", 
+    "name": "gold:Gp0127641_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127641", 
+    "url": "https://data.microbiomedata.org/1781_100343/img_annotation/Ga0482229_proteins.faa", 
+    "md5_checksum": "d10b0c9b0d5e646d09c570eb2e08b793", 
+    "file_size_bytes": 54853744, 
+    "id": "nmdc:d10b0c9b0d5e646d09c570eb2e08b793", 
+    "name": "gold:Gp0127641_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127641", 
+    "url": "https://data.microbiomedata.org/1781_100343/img_annotation/Ga0482229_structural_annotation.gff", 
+    "md5_checksum": "a33ac2dc640b7088767a99517f22421f", 
+    "file_size_bytes": 31467067, 
+    "id": "nmdc:a33ac2dc640b7088767a99517f22421f", 
+    "name": "gold:Gp0127641_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127642", 
+    "url": "https://data.microbiomedata.org/1781_100344/img_annotation/Ga0482228_ec.tsv", 
+    "md5_checksum": "4f8de602126deeb9ef60cf5f739d601a", 
+    "file_size_bytes": 2136578, 
+    "id": "nmdc:4f8de602126deeb9ef60cf5f739d601a", 
+    "name": "gold:Gp0127642_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127642", 
+    "url": "https://data.microbiomedata.org/1781_100344/img_annotation/Ga0482228_ko.tsv", 
+    "md5_checksum": "65319d4c3ffdbf5dcdb2e2837aea8cf4", 
+    "file_size_bytes": 3181379, 
+    "id": "nmdc:65319d4c3ffdbf5dcdb2e2837aea8cf4", 
+    "name": "gold:Gp0127642_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127642", 
+    "url": "https://data.microbiomedata.org/1781_100344/img_annotation/Ga0482228_functional_annotation.gff", 
+    "md5_checksum": "657b2348517d3e169df0914f5d8a2d21", 
+    "file_size_bytes": 29205678, 
+    "id": "nmdc:657b2348517d3e169df0914f5d8a2d21", 
+    "name": "gold:Gp0127642_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127642", 
+    "url": "https://data.microbiomedata.org/1781_100344/img_annotation/Ga0482228_proteins.faa", 
+    "md5_checksum": "263acdd17bdb9ed72102610070da3d65", 
+    "file_size_bytes": 25314805, 
+    "id": "nmdc:263acdd17bdb9ed72102610070da3d65", 
+    "name": "gold:Gp0127642_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127642", 
+    "url": "https://data.microbiomedata.org/1781_100344/img_annotation/Ga0482228_structural_annotation.gff", 
+    "md5_checksum": "9e55f66e86f57487e23029b90a84c4a4", 
+    "file_size_bytes": 15621635, 
+    "id": "nmdc:9e55f66e86f57487e23029b90a84c4a4", 
+    "name": "gold:Gp0127642_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127643", 
+    "url": "https://data.microbiomedata.org/1781_100345/img_annotation/Ga0482227_ec.tsv", 
+    "md5_checksum": "0b7fc1ad662f267eaa604075f9968b7c", 
+    "file_size_bytes": 4514249, 
+    "id": "nmdc:0b7fc1ad662f267eaa604075f9968b7c", 
+    "name": "gold:Gp0127643_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127643", 
+    "url": "https://data.microbiomedata.org/1781_100345/img_annotation/Ga0482227_ko.tsv", 
+    "md5_checksum": "b7b422e726f82668cd9c2ea9f0786f41", 
+    "file_size_bytes": 6888047, 
+    "id": "nmdc:b7b422e726f82668cd9c2ea9f0786f41", 
+    "name": "gold:Gp0127643_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127643", 
+    "url": "https://data.microbiomedata.org/1781_100345/img_annotation/Ga0482227_functional_annotation.gff", 
+    "md5_checksum": "f8df0729f51da70739b75a2458e32020", 
+    "file_size_bytes": 65287977, 
+    "id": "nmdc:f8df0729f51da70739b75a2458e32020", 
+    "name": "gold:Gp0127643_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127643", 
+    "url": "https://data.microbiomedata.org/1781_100345/img_annotation/Ga0482227_proteins.faa", 
+    "md5_checksum": "7434bd60874fc6d05530ee0652a9e18f", 
+    "file_size_bytes": 60688814, 
+    "id": "nmdc:7434bd60874fc6d05530ee0652a9e18f", 
+    "name": "gold:Gp0127643_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127643", 
+    "url": "https://data.microbiomedata.org/1781_100345/img_annotation/Ga0482227_structural_annotation.gff", 
+    "md5_checksum": "d897fea88896a93843966962f6bbb7be", 
+    "file_size_bytes": 34717514, 
+    "id": "nmdc:d897fea88896a93843966962f6bbb7be", 
+    "name": "gold:Gp0127643_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127644", 
+    "url": "https://data.microbiomedata.org/1781_100346/img_annotation/Ga0482226_ec.tsv", 
+    "md5_checksum": "03c32c8ae757623520f6211ff641c40a", 
+    "file_size_bytes": 1065116, 
+    "id": "nmdc:03c32c8ae757623520f6211ff641c40a", 
+    "name": "gold:Gp0127644_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127644", 
+    "url": "https://data.microbiomedata.org/1781_100346/img_annotation/Ga0482226_ko.tsv", 
+    "md5_checksum": "3eced892c4712a2b13e805a978ec0819", 
+    "file_size_bytes": 1561411, 
+    "id": "nmdc:3eced892c4712a2b13e805a978ec0819", 
+    "name": "gold:Gp0127644_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127644", 
+    "url": "https://data.microbiomedata.org/1781_100346/img_annotation/Ga0482226_functional_annotation.gff", 
+    "md5_checksum": "0626957517790befa95e8fefad58be0c", 
+    "file_size_bytes": 13709889, 
+    "id": "nmdc:0626957517790befa95e8fefad58be0c", 
+    "name": "gold:Gp0127644_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127644", 
+    "url": "https://data.microbiomedata.org/1781_100346/img_annotation/Ga0482226_proteins.faa", 
+    "md5_checksum": "2c7d55cbee1f35793da90275740d3651", 
+    "file_size_bytes": 12155198, 
+    "id": "nmdc:2c7d55cbee1f35793da90275740d3651", 
+    "name": "gold:Gp0127644_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127644", 
+    "url": "https://data.microbiomedata.org/1781_100346/img_annotation/Ga0482226_structural_annotation.gff", 
+    "md5_checksum": "0973e6d47848f6677ced2a8d463670fa", 
+    "file_size_bytes": 7177447, 
+    "id": "nmdc:0973e6d47848f6677ced2a8d463670fa", 
+    "name": "gold:Gp0127644_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127645", 
+    "url": "https://data.microbiomedata.org/1781_100347/img_annotation/Ga0482225_ec.tsv", 
+    "md5_checksum": "17524561a0e1f2c9d9ffdebc3b2df6a8", 
+    "file_size_bytes": 2346214, 
+    "id": "nmdc:17524561a0e1f2c9d9ffdebc3b2df6a8", 
+    "name": "gold:Gp0127645_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127645", 
+    "url": "https://data.microbiomedata.org/1781_100347/img_annotation/Ga0482225_ko.tsv", 
+    "md5_checksum": "e2b3ea50301aa3efaea18732ddba04f4", 
+    "file_size_bytes": 3427036, 
+    "id": "nmdc:e2b3ea50301aa3efaea18732ddba04f4", 
+    "name": "gold:Gp0127645_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127645", 
+    "url": "https://data.microbiomedata.org/1781_100347/img_annotation/Ga0482225_functional_annotation.gff", 
+    "md5_checksum": "c3a8cfa76e5da83b2b24bc6a52f71952", 
+    "file_size_bytes": 31124830, 
+    "id": "nmdc:c3a8cfa76e5da83b2b24bc6a52f71952", 
+    "name": "gold:Gp0127645_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127645", 
+    "url": "https://data.microbiomedata.org/1781_100347/img_annotation/Ga0482225_proteins.faa", 
+    "md5_checksum": "2ab0820d09b9c331ec56d7d3e20552e6", 
+    "file_size_bytes": 27535819, 
+    "id": "nmdc:2ab0820d09b9c331ec56d7d3e20552e6", 
+    "name": "gold:Gp0127645_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127645", 
+    "url": "https://data.microbiomedata.org/1781_100347/img_annotation/Ga0482225_structural_annotation.gff", 
+    "md5_checksum": "06280b3737fbf704d850ac68da190166", 
+    "file_size_bytes": 16601482, 
+    "id": "nmdc:06280b3737fbf704d850ac68da190166", 
+    "name": "gold:Gp0127645_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127646", 
+    "url": "https://data.microbiomedata.org/1781_100348/img_annotation/Ga0482224_ec.tsv", 
+    "md5_checksum": "9d87100ad8b6278b4a442c4686d7aef7", 
+    "file_size_bytes": 1499799, 
+    "id": "nmdc:9d87100ad8b6278b4a442c4686d7aef7", 
+    "name": "gold:Gp0127646_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127646", 
+    "url": "https://data.microbiomedata.org/1781_100348/img_annotation/Ga0482224_ko.tsv", 
+    "md5_checksum": "5cd2f970cbb8eb5d8e52ac7a08bfb9a3", 
+    "file_size_bytes": 2267788, 
+    "id": "nmdc:5cd2f970cbb8eb5d8e52ac7a08bfb9a3", 
+    "name": "gold:Gp0127646_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127646", 
+    "url": "https://data.microbiomedata.org/1781_100348/img_annotation/Ga0482224_functional_annotation.gff", 
+    "md5_checksum": "c0858f9a847f241ed28f454adb580bf4", 
+    "file_size_bytes": 20827107, 
+    "id": "nmdc:c0858f9a847f241ed28f454adb580bf4", 
+    "name": "gold:Gp0127646_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127646", 
+    "url": "https://data.microbiomedata.org/1781_100348/img_annotation/Ga0482224_proteins.faa", 
+    "md5_checksum": "646648c11733f7ab7ea23008729360ce", 
+    "file_size_bytes": 17791152, 
+    "id": "nmdc:646648c11733f7ab7ea23008729360ce", 
+    "name": "gold:Gp0127646_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127646", 
+    "url": "https://data.microbiomedata.org/1781_100348/img_annotation/Ga0482224_structural_annotation.gff", 
+    "md5_checksum": "94574634e1ccfe241af033259e27df1a", 
+    "file_size_bytes": 11249317, 
+    "id": "nmdc:94574634e1ccfe241af033259e27df1a", 
+    "name": "gold:Gp0127646_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127647", 
+    "url": "https://data.microbiomedata.org/1781_100349/img_annotation/Ga0482223_ec.tsv", 
+    "md5_checksum": "18d40bd5ff2707ba9a4512363d05537d", 
+    "file_size_bytes": 1837556, 
+    "id": "nmdc:18d40bd5ff2707ba9a4512363d05537d", 
+    "name": "gold:Gp0127647_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127647", 
+    "url": "https://data.microbiomedata.org/1781_100349/img_annotation/Ga0482223_ko.tsv", 
+    "md5_checksum": "d855bc2d72a6ba238acfe746299cf26a", 
+    "file_size_bytes": 2790847, 
+    "id": "nmdc:d855bc2d72a6ba238acfe746299cf26a", 
+    "name": "gold:Gp0127647_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127647", 
+    "url": "https://data.microbiomedata.org/1781_100349/img_annotation/Ga0482223_functional_annotation.gff", 
+    "md5_checksum": "af2496c3ae96ff31e6bdaae75b507ea7", 
+    "file_size_bytes": 25627980, 
+    "id": "nmdc:af2496c3ae96ff31e6bdaae75b507ea7", 
+    "name": "gold:Gp0127647_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127647", 
+    "url": "https://data.microbiomedata.org/1781_100349/img_annotation/Ga0482223_proteins.faa", 
+    "md5_checksum": "ec6d01297279eee2d4c03ecfda9309c9", 
+    "file_size_bytes": 22236480, 
+    "id": "nmdc:ec6d01297279eee2d4c03ecfda9309c9", 
+    "name": "gold:Gp0127647_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127647", 
+    "url": "https://data.microbiomedata.org/1781_100349/img_annotation/Ga0482223_structural_annotation.gff", 
+    "md5_checksum": "a57c9b7f192351676e897b8187cf6641", 
+    "file_size_bytes": 13784263, 
+    "id": "nmdc:a57c9b7f192351676e897b8187cf6641", 
+    "name": "gold:Gp0127647_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127648", 
+    "url": "https://data.microbiomedata.org/1781_100350/img_annotation/Ga0482222_ec.tsv", 
+    "md5_checksum": "06042b9d083bd6b9879bc5486c0b38ba", 
+    "file_size_bytes": 3173417, 
+    "id": "nmdc:06042b9d083bd6b9879bc5486c0b38ba", 
+    "name": "gold:Gp0127648_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127648", 
+    "url": "https://data.microbiomedata.org/1781_100350/img_annotation/Ga0482222_ko.tsv", 
+    "md5_checksum": "1287c2532770a0f0d6792192c7400c0c", 
+    "file_size_bytes": 4766831, 
+    "id": "nmdc:1287c2532770a0f0d6792192c7400c0c", 
+    "name": "gold:Gp0127648_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127648", 
+    "url": "https://data.microbiomedata.org/1781_100350/img_annotation/Ga0482222_functional_annotation.gff", 
+    "md5_checksum": "c11e44f28b422233e151d324d2accb43", 
+    "file_size_bytes": 42958010, 
+    "id": "nmdc:c11e44f28b422233e151d324d2accb43", 
+    "name": "gold:Gp0127648_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127648", 
+    "url": "https://data.microbiomedata.org/1781_100350/img_annotation/Ga0482222_proteins.faa", 
+    "md5_checksum": "d27fabc532b52dec4afa4673f920633a", 
+    "file_size_bytes": 38031105, 
+    "id": "nmdc:d27fabc532b52dec4afa4673f920633a", 
+    "name": "gold:Gp0127648_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127648", 
+    "url": "https://data.microbiomedata.org/1781_100350/img_annotation/Ga0482222_structural_annotation.gff", 
+    "md5_checksum": "863f93ecf208a6e19f17d460d8e1a963", 
+    "file_size_bytes": 22865968, 
+    "id": "nmdc:863f93ecf208a6e19f17d460d8e1a963", 
+    "name": "gold:Gp0127648_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127649", 
+    "url": "https://data.microbiomedata.org/1781_100351/img_annotation/Ga0482221_ec.tsv", 
+    "md5_checksum": "a14b836f963c0f6b02a70f0fc8cd40c0", 
+    "file_size_bytes": 4243253, 
+    "id": "nmdc:a14b836f963c0f6b02a70f0fc8cd40c0", 
+    "name": "gold:Gp0127649_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127649", 
+    "url": "https://data.microbiomedata.org/1781_100351/img_annotation/Ga0482221_ko.tsv", 
+    "md5_checksum": "35c0fd91c2225f595df469b61ba9578b", 
+    "file_size_bytes": 6334287, 
+    "id": "nmdc:35c0fd91c2225f595df469b61ba9578b", 
+    "name": "gold:Gp0127649_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127649", 
+    "url": "https://data.microbiomedata.org/1781_100351/img_annotation/Ga0482221_functional_annotation.gff", 
+    "md5_checksum": "a022fd9c3254ad5dc6ae5be40cd35c0b", 
+    "file_size_bytes": 57723284, 
+    "id": "nmdc:a022fd9c3254ad5dc6ae5be40cd35c0b", 
+    "name": "gold:Gp0127649_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127649", 
+    "url": "https://data.microbiomedata.org/1781_100351/img_annotation/Ga0482221_proteins.faa", 
+    "md5_checksum": "56c3ac34fb2f1c2ba7bcd9bd56be731a", 
+    "file_size_bytes": 52459717, 
+    "id": "nmdc:56c3ac34fb2f1c2ba7bcd9bd56be731a", 
+    "name": "gold:Gp0127649_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127649", 
+    "url": "https://data.microbiomedata.org/1781_100351/img_annotation/Ga0482221_structural_annotation.gff", 
+    "md5_checksum": "cff0a71781a84c7096ee79b39c3336f8", 
+    "file_size_bytes": 30664291, 
+    "id": "nmdc:cff0a71781a84c7096ee79b39c3336f8", 
+    "name": "gold:Gp0127649_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127651", 
+    "url": "https://data.microbiomedata.org/1781_100353/img_annotation/Ga0482220_ec.tsv", 
+    "md5_checksum": "2a7c5ba82dff4dd5d996ad5bc824103c", 
+    "file_size_bytes": 4038792, 
+    "id": "nmdc:2a7c5ba82dff4dd5d996ad5bc824103c", 
+    "name": "gold:Gp0127651_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127651", 
+    "url": "https://data.microbiomedata.org/1781_100353/img_annotation/Ga0482220_ko.tsv", 
+    "md5_checksum": "84dc1abc2d39254da6c3d2cd6cff6d9d", 
+    "file_size_bytes": 5983828, 
+    "id": "nmdc:84dc1abc2d39254da6c3d2cd6cff6d9d", 
+    "name": "gold:Gp0127651_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127651", 
+    "url": "https://data.microbiomedata.org/1781_100353/img_annotation/Ga0482220_functional_annotation.gff", 
+    "md5_checksum": "e25cb289f398c007806c72c080724872", 
+    "file_size_bytes": 55836194, 
+    "id": "nmdc:e25cb289f398c007806c72c080724872", 
+    "name": "gold:Gp0127651_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127651", 
+    "url": "https://data.microbiomedata.org/1781_100353/img_annotation/Ga0482220_proteins.faa", 
+    "md5_checksum": "67dfacdfc27cb6b0ec4787e1a40d9547", 
+    "file_size_bytes": 51634393, 
+    "id": "nmdc:67dfacdfc27cb6b0ec4787e1a40d9547", 
+    "name": "gold:Gp0127651_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127651", 
+    "url": "https://data.microbiomedata.org/1781_100353/img_annotation/Ga0482220_structural_annotation.gff", 
+    "md5_checksum": "714fb73a8b3011d0b2faea98eda477c3", 
+    "file_size_bytes": 29616524, 
+    "id": "nmdc:714fb73a8b3011d0b2faea98eda477c3", 
+    "name": "gold:Gp0127651_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127652", 
+    "url": "https://data.microbiomedata.org/1781_100354/img_annotation/Ga0482219_ec.tsv", 
+    "md5_checksum": "06ceb99673dcb924ca223539267a962a", 
+    "file_size_bytes": 4820507, 
+    "id": "nmdc:06ceb99673dcb924ca223539267a962a", 
+    "name": "gold:Gp0127652_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127652", 
+    "url": "https://data.microbiomedata.org/1781_100354/img_annotation/Ga0482219_ko.tsv", 
+    "md5_checksum": "4d16f813aefc09c7720770f065964c49", 
+    "file_size_bytes": 7251067, 
+    "id": "nmdc:4d16f813aefc09c7720770f065964c49", 
+    "name": "gold:Gp0127652_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127652", 
+    "url": "https://data.microbiomedata.org/1781_100354/img_annotation/Ga0482219_functional_annotation.gff", 
+    "md5_checksum": "80c28fa3efc78e6d23d0abcf1161c983", 
+    "file_size_bytes": 67752362, 
+    "id": "nmdc:80c28fa3efc78e6d23d0abcf1161c983", 
+    "name": "gold:Gp0127652_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127652", 
+    "url": "https://data.microbiomedata.org/1781_100354/img_annotation/Ga0482219_proteins.faa", 
+    "md5_checksum": "48bb698de57cd77bf1ddda9004e89c01", 
+    "file_size_bytes": 63206704, 
+    "id": "nmdc:48bb698de57cd77bf1ddda9004e89c01", 
+    "name": "gold:Gp0127652_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127652", 
+    "url": "https://data.microbiomedata.org/1781_100354/img_annotation/Ga0482219_structural_annotation.gff", 
+    "md5_checksum": "6b39045cb99ca6220e27c4fa960f4dd1", 
+    "file_size_bytes": 36012373, 
+    "id": "nmdc:6b39045cb99ca6220e27c4fa960f4dd1", 
+    "name": "gold:Gp0127652_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127653", 
+    "url": "https://data.microbiomedata.org/1781_100355/img_annotation/Ga0482218_ec.tsv", 
+    "md5_checksum": "05cc9ce5321d6bc909ab63b8cbc59d02", 
+    "file_size_bytes": 886492, 
+    "id": "nmdc:05cc9ce5321d6bc909ab63b8cbc59d02", 
+    "name": "gold:Gp0127653_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127653", 
+    "url": "https://data.microbiomedata.org/1781_100355/img_annotation/Ga0482218_ko.tsv", 
+    "md5_checksum": "44f8e708349a1effdff745880f4fdd12", 
+    "file_size_bytes": 1355686, 
+    "id": "nmdc:44f8e708349a1effdff745880f4fdd12", 
+    "name": "gold:Gp0127653_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127653", 
+    "url": "https://data.microbiomedata.org/1781_100355/img_annotation/Ga0482218_functional_annotation.gff", 
+    "md5_checksum": "8d83e502a533b5db8cd3bc943ae8b18b", 
+    "file_size_bytes": 12497188, 
+    "id": "nmdc:8d83e502a533b5db8cd3bc943ae8b18b", 
+    "name": "gold:Gp0127653_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127653", 
+    "url": "https://data.microbiomedata.org/1781_100355/img_annotation/Ga0482218_proteins.faa", 
+    "md5_checksum": "658231efecf9d087ec2a6e9467f4e968", 
+    "file_size_bytes": 10476759, 
+    "id": "nmdc:658231efecf9d087ec2a6e9467f4e968", 
+    "name": "gold:Gp0127653_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127653", 
+    "url": "https://data.microbiomedata.org/1781_100355/img_annotation/Ga0482218_structural_annotation.gff", 
+    "md5_checksum": "511ae319ddff2bdcbc3296d951e42d7e", 
+    "file_size_bytes": 6769084, 
+    "id": "nmdc:511ae319ddff2bdcbc3296d951e42d7e", 
+    "name": "gold:Gp0127653_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127654", 
+    "url": "https://data.microbiomedata.org/1781_100356/img_annotation/Ga0482217_ec.tsv", 
+    "md5_checksum": "b785c7809fa99d5beca859eded4a9b0f", 
+    "file_size_bytes": 4410668, 
+    "id": "nmdc:b785c7809fa99d5beca859eded4a9b0f", 
+    "name": "gold:Gp0127654_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127654", 
+    "url": "https://data.microbiomedata.org/1781_100356/img_annotation/Ga0482217_ko.tsv", 
+    "md5_checksum": "3b7734343770dce929591ee83d96acb6", 
+    "file_size_bytes": 6599735, 
+    "id": "nmdc:3b7734343770dce929591ee83d96acb6", 
+    "name": "gold:Gp0127654_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127654", 
+    "url": "https://data.microbiomedata.org/1781_100356/img_annotation/Ga0482217_functional_annotation.gff", 
+    "md5_checksum": "b28a675c6560b34691a960f7e873841d", 
+    "file_size_bytes": 58514458, 
+    "id": "nmdc:b28a675c6560b34691a960f7e873841d", 
+    "name": "gold:Gp0127654_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127654", 
+    "url": "https://data.microbiomedata.org/1781_100356/img_annotation/Ga0482217_proteins.faa", 
+    "md5_checksum": "deda4116aac7e262c0edf3358bb8e384", 
+    "file_size_bytes": 52262534, 
+    "id": "nmdc:deda4116aac7e262c0edf3358bb8e384", 
+    "name": "gold:Gp0127654_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127654", 
+    "url": "https://data.microbiomedata.org/1781_100356/img_annotation/Ga0482217_structural_annotation.gff", 
+    "md5_checksum": "a9cf54b925e1c5b8c3e0299730f5a464", 
+    "file_size_bytes": 31061853, 
+    "id": "nmdc:a9cf54b925e1c5b8c3e0299730f5a464", 
+    "name": "gold:Gp0127654_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127655", 
+    "url": "https://data.microbiomedata.org/1781_100357/img_annotation/Ga0482216_ec.tsv", 
+    "md5_checksum": "32c6c6dbce4a1c6ab92810a86f90c574", 
+    "file_size_bytes": 3992645, 
+    "id": "nmdc:32c6c6dbce4a1c6ab92810a86f90c574", 
+    "name": "gold:Gp0127655_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127655", 
+    "url": "https://data.microbiomedata.org/1781_100357/img_annotation/Ga0482216_ko.tsv", 
+    "md5_checksum": "6d1185f4034e364b74109d40326a450a", 
+    "file_size_bytes": 6056509, 
+    "id": "nmdc:6d1185f4034e364b74109d40326a450a", 
+    "name": "gold:Gp0127655_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127655", 
+    "url": "https://data.microbiomedata.org/1781_100357/img_annotation/Ga0482216_functional_annotation.gff", 
+    "md5_checksum": "0b4a5dc91c42b7fea3fd514d5cb3138b", 
+    "file_size_bytes": 55992778, 
+    "id": "nmdc:0b4a5dc91c42b7fea3fd514d5cb3138b", 
+    "name": "gold:Gp0127655_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127655", 
+    "url": "https://data.microbiomedata.org/1781_100357/img_annotation/Ga0482216_proteins.faa", 
+    "md5_checksum": "a31096eb3e473fd0c68d09096bc3fd85", 
+    "file_size_bytes": 51153871, 
+    "id": "nmdc:a31096eb3e473fd0c68d09096bc3fd85", 
+    "name": "gold:Gp0127655_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127655", 
+    "url": "https://data.microbiomedata.org/1781_100357/img_annotation/Ga0482216_structural_annotation.gff", 
+    "md5_checksum": "05e2702ecae6ba0ba0b0898132850b9f", 
+    "file_size_bytes": 29673466, 
+    "id": "nmdc:05e2702ecae6ba0ba0b0898132850b9f", 
+    "name": "gold:Gp0127655_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0127656", 
+    "url": "https://data.microbiomedata.org/1781_100633/img_annotation/Ga0482215_ec.tsv", 
+    "md5_checksum": "33e0f5ff7c448ded210f04798894a031", 
+    "file_size_bytes": 3740980, 
+    "id": "nmdc:33e0f5ff7c448ded210f04798894a031", 
+    "name": "gold:Gp0127656_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0127656", 
+    "url": "https://data.microbiomedata.org/1781_100633/img_annotation/Ga0482215_ko.tsv", 
+    "md5_checksum": "8d230dd7948d2b08c4de1adc0d0002b8", 
+    "file_size_bytes": 5601366, 
+    "id": "nmdc:8d230dd7948d2b08c4de1adc0d0002b8", 
+    "name": "gold:Gp0127656_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0127656", 
+    "url": "https://data.microbiomedata.org/1781_100633/img_annotation/Ga0482215_functional_annotation.gff", 
+    "md5_checksum": "00f42710ff9df37cd23e5e73d54e4dd1", 
+    "file_size_bytes": 49962259, 
+    "id": "nmdc:00f42710ff9df37cd23e5e73d54e4dd1", 
+    "name": "gold:Gp0127656_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0127656", 
+    "url": "https://data.microbiomedata.org/1781_100633/img_annotation/Ga0482215_proteins.faa", 
+    "md5_checksum": "2819bbb349ca5bdbf311aeae6ada532b", 
+    "file_size_bytes": 44508190, 
+    "id": "nmdc:2819bbb349ca5bdbf311aeae6ada532b", 
+    "name": "gold:Gp0127656_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0127656", 
+    "url": "https://data.microbiomedata.org/1781_100633/img_annotation/Ga0482215_structural_annotation.gff", 
+    "md5_checksum": "0c2ae5a86d4840a0b324d73977170f1e", 
+    "file_size_bytes": 26532162, 
+    "id": "nmdc:0c2ae5a86d4840a0b324d73977170f1e", 
+    "name": "gold:Gp0127656_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115664", 
+    "url": "https://data.microbiomedata.org/1781_86089/img_annotation/Ga0482263_ec.tsv", 
+    "md5_checksum": "8a812604db9b4e2bdbad6d0b3539f6ea", 
+    "file_size_bytes": 1622615, 
+    "id": "nmdc:8a812604db9b4e2bdbad6d0b3539f6ea", 
+    "name": "gold:Gp0115664_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115664", 
+    "url": "https://data.microbiomedata.org/1781_86089/img_annotation/Ga0482263_ko.tsv", 
+    "md5_checksum": "76537a4ab5012ba3b407471da373ef1c", 
+    "file_size_bytes": 2470784, 
+    "id": "nmdc:76537a4ab5012ba3b407471da373ef1c", 
+    "name": "gold:Gp0115664_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115664", 
+    "url": "https://data.microbiomedata.org/1781_86089/img_annotation/Ga0482263_functional_annotation.gff", 
+    "md5_checksum": "bc034c7024043ea88b44d0897bb5bece", 
+    "file_size_bytes": 22077188, 
+    "id": "nmdc:bc034c7024043ea88b44d0897bb5bece", 
+    "name": "gold:Gp0115664_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115664", 
+    "url": "https://data.microbiomedata.org/1781_86089/img_annotation/Ga0482263_proteins.faa", 
+    "md5_checksum": "fc419491cce16671e828d76083252841", 
+    "file_size_bytes": 19851551, 
+    "id": "nmdc:fc419491cce16671e828d76083252841", 
+    "name": "gold:Gp0115664_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115664", 
+    "url": "https://data.microbiomedata.org/1781_86089/img_annotation/Ga0482263_structural_annotation.gff", 
+    "md5_checksum": "10117f9500d0dd54655a5d70195f7df5", 
+    "file_size_bytes": 11914561, 
+    "id": "nmdc:10117f9500d0dd54655a5d70195f7df5", 
+    "name": "gold:Gp0115664_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115675", 
+    "url": "https://data.microbiomedata.org/1781_86090/img_annotation/Ga0482252_ec.tsv", 
+    "md5_checksum": "b30bdfcd025588bd80ebb3bcdad2cdc8", 
+    "file_size_bytes": 1979387, 
+    "id": "nmdc:b30bdfcd025588bd80ebb3bcdad2cdc8", 
+    "name": "gold:Gp0115675_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115675", 
+    "url": "https://data.microbiomedata.org/1781_86090/img_annotation/Ga0482252_ko.tsv", 
+    "md5_checksum": "7ab72f45de20843e167ee1e595bb752d", 
+    "file_size_bytes": 3077135, 
+    "id": "nmdc:7ab72f45de20843e167ee1e595bb752d", 
+    "name": "gold:Gp0115675_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115675", 
+    "url": "https://data.microbiomedata.org/1781_86090/img_annotation/Ga0482252_functional_annotation.gff", 
+    "md5_checksum": "e745ff0c0a95c89393f8789cd8c409e9", 
+    "file_size_bytes": 24087754, 
+    "id": "nmdc:e745ff0c0a95c89393f8789cd8c409e9", 
+    "name": "gold:Gp0115675_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115675", 
+    "url": "https://data.microbiomedata.org/1781_86090/img_annotation/Ga0482252_proteins.faa", 
+    "md5_checksum": "51f3c008db6a106ee14e160f35f7d9f3", 
+    "file_size_bytes": 22158343, 
+    "id": "nmdc:51f3c008db6a106ee14e160f35f7d9f3", 
+    "name": "gold:Gp0115675_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115675", 
+    "url": "https://data.microbiomedata.org/1781_86090/img_annotation/Ga0482252_structural_annotation.gff", 
+    "md5_checksum": "dcb8211231f718d57e22f8dea1efc6d0", 
+    "file_size_bytes": 12665204, 
+    "id": "nmdc:dcb8211231f718d57e22f8dea1efc6d0", 
+    "name": "gold:Gp0115675_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115673", 
+    "url": "https://data.microbiomedata.org/1781_86091/img_annotation/Ga0482254_ec.tsv", 
+    "md5_checksum": "da4d331daa6d5965be8e201c3c9ba4d4", 
+    "file_size_bytes": 2300998, 
+    "id": "nmdc:da4d331daa6d5965be8e201c3c9ba4d4", 
+    "name": "gold:Gp0115673_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115673", 
+    "url": "https://data.microbiomedata.org/1781_86091/img_annotation/Ga0482254_ko.tsv", 
+    "md5_checksum": "73cac6bcbfa2627ab291bf230ded9748", 
+    "file_size_bytes": 3565804, 
+    "id": "nmdc:73cac6bcbfa2627ab291bf230ded9748", 
+    "name": "gold:Gp0115673_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115673", 
+    "url": "https://data.microbiomedata.org/1781_86091/img_annotation/Ga0482254_functional_annotation.gff", 
+    "md5_checksum": "b7264d7a1c56fc32c4a0c050fe04208e", 
+    "file_size_bytes": 27802385, 
+    "id": "nmdc:b7264d7a1c56fc32c4a0c050fe04208e", 
+    "name": "gold:Gp0115673_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115673", 
+    "url": "https://data.microbiomedata.org/1781_86091/img_annotation/Ga0482254_proteins.faa", 
+    "md5_checksum": "d325906b9b82b3bfc2fe8ed7321a828e", 
+    "file_size_bytes": 26077695, 
+    "id": "nmdc:d325906b9b82b3bfc2fe8ed7321a828e", 
+    "name": "gold:Gp0115673_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115673", 
+    "url": "https://data.microbiomedata.org/1781_86091/img_annotation/Ga0482254_structural_annotation.gff", 
+    "md5_checksum": "2fba563f11988f4e30d2b4283c3c5487", 
+    "file_size_bytes": 14569459, 
+    "id": "nmdc:2fba563f11988f4e30d2b4283c3c5487", 
+    "name": "gold:Gp0115673_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115677", 
+    "url": "https://data.microbiomedata.org/1781_86092/img_annotation/Ga0482250_ec.tsv", 
+    "md5_checksum": "8a39e09943350e563b00e23a146c3ec1", 
+    "file_size_bytes": 10831709, 
+    "id": "nmdc:8a39e09943350e563b00e23a146c3ec1", 
+    "name": "gold:Gp0115677_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115677", 
+    "url": "https://data.microbiomedata.org/1781_86092/img_annotation/Ga0482250_ko.tsv", 
+    "md5_checksum": "34d53203f08e6c25c8f85f6e04d6df24", 
+    "file_size_bytes": 16670222, 
+    "id": "nmdc:34d53203f08e6c25c8f85f6e04d6df24", 
+    "name": "gold:Gp0115677_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115677", 
+    "url": "https://data.microbiomedata.org/1781_86092/img_annotation/Ga0482250_functional_annotation.gff", 
+    "md5_checksum": "e7df895e1a7776ba16b6d77fdc9b077d", 
+    "file_size_bytes": 151971551, 
+    "id": "nmdc:e7df895e1a7776ba16b6d77fdc9b077d", 
+    "name": "gold:Gp0115677_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115677", 
+    "url": "https://data.microbiomedata.org/1781_86092/img_annotation/Ga0482250_proteins.faa", 
+    "md5_checksum": "c0365d39cb481d6e0f729b587dac10c8", 
+    "file_size_bytes": 136700201, 
+    "id": "nmdc:c0365d39cb481d6e0f729b587dac10c8", 
+    "name": "gold:Gp0115677_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115677", 
+    "url": "https://data.microbiomedata.org/1781_86092/img_annotation/Ga0482250_structural_annotation.gff", 
+    "md5_checksum": "bfbd1bd1ad70307dd01b699ecc4ffb2a", 
+    "file_size_bytes": 82974873, 
+    "id": "nmdc:bfbd1bd1ad70307dd01b699ecc4ffb2a", 
+    "name": "gold:Gp0115677_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115678", 
+    "url": "https://data.microbiomedata.org/1781_86093/img_annotation/Ga0482249_ec.tsv", 
+    "md5_checksum": "240064338b65f944556e88ebd44fbd03", 
+    "file_size_bytes": 7122055, 
+    "id": "nmdc:240064338b65f944556e88ebd44fbd03", 
+    "name": "gold:Gp0115678_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115678", 
+    "url": "https://data.microbiomedata.org/1781_86093/img_annotation/Ga0482249_ko.tsv", 
+    "md5_checksum": "cfe4a8ce52735eedacc38bacdc8785e4", 
+    "file_size_bytes": 11086262, 
+    "id": "nmdc:cfe4a8ce52735eedacc38bacdc8785e4", 
+    "name": "gold:Gp0115678_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115678", 
+    "url": "https://data.microbiomedata.org/1781_86093/img_annotation/Ga0482249_functional_annotation.gff", 
+    "md5_checksum": "6d1553b3e100a61f3b2b453fb7e71094", 
+    "file_size_bytes": 107649576, 
+    "id": "nmdc:6d1553b3e100a61f3b2b453fb7e71094", 
+    "name": "gold:Gp0115678_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115678", 
+    "url": "https://data.microbiomedata.org/1781_86093/img_annotation/Ga0482249_proteins.faa", 
+    "md5_checksum": "78a99f435ce2bdd6cd83ebb807dc0ef3", 
+    "file_size_bytes": 103798238, 
+    "id": "nmdc:78a99f435ce2bdd6cd83ebb807dc0ef3", 
+    "name": "gold:Gp0115678_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115678", 
+    "url": "https://data.microbiomedata.org/1781_86093/img_annotation/Ga0482249_structural_annotation.gff", 
+    "md5_checksum": "ac989404b8a9e07880788cfb061015ba", 
+    "file_size_bytes": 58848987, 
+    "id": "nmdc:ac989404b8a9e07880788cfb061015ba", 
+    "name": "gold:Gp0115678_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115665", 
+    "url": "https://data.microbiomedata.org/1781_86094/img_annotation/Ga0482262_ec.tsv", 
+    "md5_checksum": "b4a623a8d9418c04567b5712889fcdfd", 
+    "file_size_bytes": 7245176, 
+    "id": "nmdc:b4a623a8d9418c04567b5712889fcdfd", 
+    "name": "gold:Gp0115665_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115665", 
+    "url": "https://data.microbiomedata.org/1781_86094/img_annotation/Ga0482262_ko.tsv", 
+    "md5_checksum": "e28746f79f2d58d71fd5f42dff8b6dd5", 
+    "file_size_bytes": 11190329, 
+    "id": "nmdc:e28746f79f2d58d71fd5f42dff8b6dd5", 
+    "name": "gold:Gp0115665_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115665", 
+    "url": "https://data.microbiomedata.org/1781_86094/img_annotation/Ga0482262_functional_annotation.gff", 
+    "md5_checksum": "dceabe03f9758a72038b9824794337e1", 
+    "file_size_bytes": 100066025, 
+    "id": "nmdc:dceabe03f9758a72038b9824794337e1", 
+    "name": "gold:Gp0115665_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115665", 
+    "url": "https://data.microbiomedata.org/1781_86094/img_annotation/Ga0482262_proteins.faa", 
+    "md5_checksum": "1b5b79d300bb60afffec76da4cda7f14", 
+    "file_size_bytes": 95608095, 
+    "id": "nmdc:1b5b79d300bb60afffec76da4cda7f14", 
+    "name": "gold:Gp0115665_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115665", 
+    "url": "https://data.microbiomedata.org/1781_86094/img_annotation/Ga0482262_structural_annotation.gff", 
+    "md5_checksum": "431860b46c896880c1d8d779fb2645ec", 
+    "file_size_bytes": 54061867, 
+    "id": "nmdc:431860b46c896880c1d8d779fb2645ec", 
+    "name": "gold:Gp0115665_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115671", 
+    "url": "https://data.microbiomedata.org/1781_86095/img_annotation/Ga0482256_ec.tsv", 
+    "md5_checksum": "75e88ab163c9d092836f9110768c6a52", 
+    "file_size_bytes": 2795487, 
+    "id": "nmdc:75e88ab163c9d092836f9110768c6a52", 
+    "name": "gold:Gp0115671_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115671", 
+    "url": "https://data.microbiomedata.org/1781_86095/img_annotation/Ga0482256_ko.tsv", 
+    "md5_checksum": "9c6c644e821021661d936d374ee9fc1b", 
+    "file_size_bytes": 4340886, 
+    "id": "nmdc:9c6c644e821021661d936d374ee9fc1b", 
+    "name": "gold:Gp0115671_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115671", 
+    "url": "https://data.microbiomedata.org/1781_86095/img_annotation/Ga0482256_functional_annotation.gff", 
+    "md5_checksum": "8f5a7f2db6790e67282439becd4c04b2", 
+    "file_size_bytes": 34647124, 
+    "id": "nmdc:8f5a7f2db6790e67282439becd4c04b2", 
+    "name": "gold:Gp0115671_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115671", 
+    "url": "https://data.microbiomedata.org/1781_86095/img_annotation/Ga0482256_proteins.faa", 
+    "md5_checksum": "f5a4336c7ac10e908cfe90a61a991c65", 
+    "file_size_bytes": 31254418, 
+    "id": "nmdc:f5a4336c7ac10e908cfe90a61a991c65", 
+    "name": "gold:Gp0115671_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115671", 
+    "url": "https://data.microbiomedata.org/1781_86095/img_annotation/Ga0482256_structural_annotation.gff", 
+    "md5_checksum": "ad6e88d469fbad7b0684afb933403a6c", 
+    "file_size_bytes": 18465493, 
+    "id": "nmdc:ad6e88d469fbad7b0684afb933403a6c", 
+    "name": "gold:Gp0115671_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115666", 
+    "url": "https://data.microbiomedata.org/1781_86096/img_annotation/Ga0482261_ec.tsv", 
+    "md5_checksum": "4e3f389524497182aa3e8832aa7b373b", 
+    "file_size_bytes": 3118709, 
+    "id": "nmdc:4e3f389524497182aa3e8832aa7b373b", 
+    "name": "gold:Gp0115666_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115666", 
+    "url": "https://data.microbiomedata.org/1781_86096/img_annotation/Ga0482261_ko.tsv", 
+    "md5_checksum": "ab262feeaf856be190b60ea7c0a4c030", 
+    "file_size_bytes": 4858471, 
+    "id": "nmdc:ab262feeaf856be190b60ea7c0a4c030", 
+    "name": "gold:Gp0115666_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115666", 
+    "url": "https://data.microbiomedata.org/1781_86096/img_annotation/Ga0482261_functional_annotation.gff", 
+    "md5_checksum": "a1e8795537eca0522357d60045780ab3", 
+    "file_size_bytes": 36548932, 
+    "id": "nmdc:a1e8795537eca0522357d60045780ab3", 
+    "name": "gold:Gp0115666_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115666", 
+    "url": "https://data.microbiomedata.org/1781_86096/img_annotation/Ga0482261_proteins.faa", 
+    "md5_checksum": "70c8e0fc6e64b20e99a4c0f783014142", 
+    "file_size_bytes": 33991383, 
+    "id": "nmdc:70c8e0fc6e64b20e99a4c0f783014142", 
+    "name": "gold:Gp0115666_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115666", 
+    "url": "https://data.microbiomedata.org/1781_86096/img_annotation/Ga0482261_structural_annotation.gff", 
+    "md5_checksum": "654201c4699079bdd923dcff52881c07", 
+    "file_size_bytes": 19240809, 
+    "id": "nmdc:654201c4699079bdd923dcff52881c07", 
+    "name": "gold:Gp0115666_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115669", 
+    "url": "https://data.microbiomedata.org/1781_86097/img_annotation/Ga0482258_ec.tsv", 
+    "md5_checksum": "e74cb5e168717574193a15d5ac04a01f", 
+    "file_size_bytes": 2695900, 
+    "id": "nmdc:e74cb5e168717574193a15d5ac04a01f", 
+    "name": "gold:Gp0115669_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115669", 
+    "url": "https://data.microbiomedata.org/1781_86097/img_annotation/Ga0482258_ko.tsv", 
+    "md5_checksum": "0bc9b55e2d8f3c45b18725845815bfde", 
+    "file_size_bytes": 4189474, 
+    "id": "nmdc:0bc9b55e2d8f3c45b18725845815bfde", 
+    "name": "gold:Gp0115669_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115669", 
+    "url": "https://data.microbiomedata.org/1781_86097/img_annotation/Ga0482258_functional_annotation.gff", 
+    "md5_checksum": "4f7a6e682f6f13b7ea73511265fdd2a9", 
+    "file_size_bytes": 33459859, 
+    "id": "nmdc:4f7a6e682f6f13b7ea73511265fdd2a9", 
+    "name": "gold:Gp0115669_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115669", 
+    "url": "https://data.microbiomedata.org/1781_86097/img_annotation/Ga0482258_proteins.faa", 
+    "md5_checksum": "6de20d427454895dce6caeb7b9543c11", 
+    "file_size_bytes": 30936372, 
+    "id": "nmdc:6de20d427454895dce6caeb7b9543c11", 
+    "name": "gold:Gp0115669_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115669", 
+    "url": "https://data.microbiomedata.org/1781_86097/img_annotation/Ga0482258_structural_annotation.gff", 
+    "md5_checksum": "9c68523f458ee1f8ec395e1442b1f508", 
+    "file_size_bytes": 17835079, 
+    "id": "nmdc:9c68523f458ee1f8ec395e1442b1f508", 
+    "name": "gold:Gp0115669_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115667", 
+    "url": "https://data.microbiomedata.org/1781_86098/img_annotation/Ga0482260_ec.tsv", 
+    "md5_checksum": "babc9f95621eed35bc7975dee8b417b9", 
+    "file_size_bytes": 1925113, 
+    "id": "nmdc:babc9f95621eed35bc7975dee8b417b9", 
+    "name": "gold:Gp0115667_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115667", 
+    "url": "https://data.microbiomedata.org/1781_86098/img_annotation/Ga0482260_ko.tsv", 
+    "md5_checksum": "bc5043b689463c3651c15ad4ba1aa9a4", 
+    "file_size_bytes": 2997986, 
+    "id": "nmdc:bc5043b689463c3651c15ad4ba1aa9a4", 
+    "name": "gold:Gp0115667_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115667", 
+    "url": "https://data.microbiomedata.org/1781_86098/img_annotation/Ga0482260_functional_annotation.gff", 
+    "md5_checksum": "c47020ef7958f3a4c4458e0797fc2400", 
+    "file_size_bytes": 31370431, 
+    "id": "nmdc:c47020ef7958f3a4c4458e0797fc2400", 
+    "name": "gold:Gp0115667_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115667", 
+    "url": "https://data.microbiomedata.org/1781_86098/img_annotation/Ga0482260_proteins.faa", 
+    "md5_checksum": "acdedd1c48e28e4f4e0d0679cae417f9", 
+    "file_size_bytes": 30011835, 
+    "id": "nmdc:acdedd1c48e28e4f4e0d0679cae417f9", 
+    "name": "gold:Gp0115667_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115667", 
+    "url": "https://data.microbiomedata.org/1781_86098/img_annotation/Ga0482260_structural_annotation.gff", 
+    "md5_checksum": "6f236cc8b728333fcf85e4f27873a500", 
+    "file_size_bytes": 17408283, 
+    "id": "nmdc:6f236cc8b728333fcf85e4f27873a500", 
+    "name": "gold:Gp0115667_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115676", 
+    "url": "https://data.microbiomedata.org/1781_86099/img_annotation/Ga0482251_ec.tsv", 
+    "md5_checksum": "bc4755bf8b2c0b7c384eb4ffd8e9e017", 
+    "file_size_bytes": 5193468, 
+    "id": "nmdc:bc4755bf8b2c0b7c384eb4ffd8e9e017", 
+    "name": "gold:Gp0115676_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115676", 
+    "url": "https://data.microbiomedata.org/1781_86099/img_annotation/Ga0482251_ko.tsv", 
+    "md5_checksum": "23762ea8dc5ce375c3827aded41ae2c0", 
+    "file_size_bytes": 7996928, 
+    "id": "nmdc:23762ea8dc5ce375c3827aded41ae2c0", 
+    "name": "gold:Gp0115676_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115676", 
+    "url": "https://data.microbiomedata.org/1781_86099/img_annotation/Ga0482251_functional_annotation.gff", 
+    "md5_checksum": "d429e7a9bb0344196ed7bcca6131e3c0", 
+    "file_size_bytes": 59520844, 
+    "id": "nmdc:d429e7a9bb0344196ed7bcca6131e3c0", 
+    "name": "gold:Gp0115676_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115676", 
+    "url": "https://data.microbiomedata.org/1781_86099/img_annotation/Ga0482251_proteins.faa", 
+    "md5_checksum": "5193d8fa7e151b96396afa8d61851af8", 
+    "file_size_bytes": 56273808, 
+    "id": "nmdc:5193d8fa7e151b96396afa8d61851af8", 
+    "name": "gold:Gp0115676_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115676", 
+    "url": "https://data.microbiomedata.org/1781_86099/img_annotation/Ga0482251_structural_annotation.gff", 
+    "md5_checksum": "e3b04bb85be48814ca078ee871a9296b", 
+    "file_size_bytes": 31122804, 
+    "id": "nmdc:e3b04bb85be48814ca078ee871a9296b", 
+    "name": "gold:Gp0115676_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115668", 
+    "url": "https://data.microbiomedata.org/1781_86100/img_annotation/Ga0482259_ec.tsv", 
+    "md5_checksum": "bcbae14f9733da2b512b5f5b6c8fcb98", 
+    "file_size_bytes": 3601293, 
+    "id": "nmdc:bcbae14f9733da2b512b5f5b6c8fcb98", 
+    "name": "gold:Gp0115668_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115668", 
+    "url": "https://data.microbiomedata.org/1781_86100/img_annotation/Ga0482259_ko.tsv", 
+    "md5_checksum": "dbd78725415f5f8e80f590c3588a1c60", 
+    "file_size_bytes": 5748812, 
+    "id": "nmdc:dbd78725415f5f8e80f590c3588a1c60", 
+    "name": "gold:Gp0115668_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115668", 
+    "url": "https://data.microbiomedata.org/1781_86100/img_annotation/Ga0482259_functional_annotation.gff", 
+    "md5_checksum": "c57d28f7dd791aab5c4caee00b247ef9", 
+    "file_size_bytes": 82905278, 
+    "id": "nmdc:c57d28f7dd791aab5c4caee00b247ef9", 
+    "name": "gold:Gp0115668_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115668", 
+    "url": "https://data.microbiomedata.org/1781_86100/img_annotation/Ga0482259_proteins.faa", 
+    "md5_checksum": "f97c44951275f8b68fa94ded40fda756", 
+    "file_size_bytes": 83554344, 
+    "id": "nmdc:f97c44951275f8b68fa94ded40fda756", 
+    "name": "gold:Gp0115668_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115668", 
+    "url": "https://data.microbiomedata.org/1781_86100/img_annotation/Ga0482259_structural_annotation.gff", 
+    "md5_checksum": "b4764f173896dcb134d7c94c1ee13ca3", 
+    "file_size_bytes": 46983892, 
+    "id": "nmdc:b4764f173896dcb134d7c94c1ee13ca3", 
+    "name": "gold:Gp0115668_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115663", 
+    "url": "https://data.microbiomedata.org/1781_86101/img_annotation/Ga0482264_ec.tsv", 
+    "md5_checksum": "27319f58c616a07159e1fac12635bd4b", 
+    "file_size_bytes": 3462448, 
+    "id": "nmdc:27319f58c616a07159e1fac12635bd4b", 
+    "name": "gold:Gp0115663_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115663", 
+    "url": "https://data.microbiomedata.org/1781_86101/img_annotation/Ga0482264_ko.tsv", 
+    "md5_checksum": "8d250650c90956edff8bafccc56fd630", 
+    "file_size_bytes": 5222482, 
+    "id": "nmdc:8d250650c90956edff8bafccc56fd630", 
+    "name": "gold:Gp0115663_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115663", 
+    "url": "https://data.microbiomedata.org/1781_86101/img_annotation/Ga0482264_functional_annotation.gff", 
+    "md5_checksum": "b7e9c8d0bffdd13ace6f862a61fa87d2", 
+    "file_size_bytes": 50075111, 
+    "id": "nmdc:b7e9c8d0bffdd13ace6f862a61fa87d2", 
+    "name": "gold:Gp0115663_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115663", 
+    "url": "https://data.microbiomedata.org/1781_86101/img_annotation/Ga0482264_proteins.faa", 
+    "md5_checksum": "754074d3bcade65aba2a6f8236619ab7", 
+    "file_size_bytes": 47666791, 
+    "id": "nmdc:754074d3bcade65aba2a6f8236619ab7", 
+    "name": "gold:Gp0115663_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115663", 
+    "url": "https://data.microbiomedata.org/1781_86101/img_annotation/Ga0482264_structural_annotation.gff", 
+    "md5_checksum": "a4b4c623457aa10161d88a9ac4eef522", 
+    "file_size_bytes": 27259728, 
+    "id": "nmdc:a4b4c623457aa10161d88a9ac4eef522", 
+    "name": "gold:Gp0115663_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115670", 
+    "url": "https://data.microbiomedata.org/1781_86102/img_annotation/Ga0482257_ec.tsv", 
+    "md5_checksum": "483453952f8e4dc70687e02842b2bfc8", 
+    "file_size_bytes": 3686194, 
+    "id": "nmdc:483453952f8e4dc70687e02842b2bfc8", 
+    "name": "gold:Gp0115670_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115670", 
+    "url": "https://data.microbiomedata.org/1781_86102/img_annotation/Ga0482257_ko.tsv", 
+    "md5_checksum": "4226d30b4f7d4018245613abbb2cc254", 
+    "file_size_bytes": 5779388, 
+    "id": "nmdc:4226d30b4f7d4018245613abbb2cc254", 
+    "name": "gold:Gp0115670_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115670", 
+    "url": "https://data.microbiomedata.org/1781_86102/img_annotation/Ga0482257_functional_annotation.gff", 
+    "md5_checksum": "75a1e23a29f8b793c0b0abb7778d8661", 
+    "file_size_bytes": 45972348, 
+    "id": "nmdc:75a1e23a29f8b793c0b0abb7778d8661", 
+    "name": "gold:Gp0115670_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115670", 
+    "url": "https://data.microbiomedata.org/1781_86102/img_annotation/Ga0482257_proteins.faa", 
+    "md5_checksum": "7e531f55eba2bd29d5bb4b1af8417b7c", 
+    "file_size_bytes": 43855527, 
+    "id": "nmdc:7e531f55eba2bd29d5bb4b1af8417b7c", 
+    "name": "gold:Gp0115670_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115670", 
+    "url": "https://data.microbiomedata.org/1781_86102/img_annotation/Ga0482257_structural_annotation.gff", 
+    "md5_checksum": "f05ecf0db08d716edb7a3f499582a2b7", 
+    "file_size_bytes": 24403141, 
+    "id": "nmdc:f05ecf0db08d716edb7a3f499582a2b7", 
+    "name": "gold:Gp0115670_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115672", 
+    "url": "https://data.microbiomedata.org/1781_86103/img_annotation/Ga0482255_ec.tsv", 
+    "md5_checksum": "e029f10a29dd5e9d81dce82c2211fdee", 
+    "file_size_bytes": 5922712, 
+    "id": "nmdc:e029f10a29dd5e9d81dce82c2211fdee", 
+    "name": "gold:Gp0115672_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115672", 
+    "url": "https://data.microbiomedata.org/1781_86103/img_annotation/Ga0482255_ko.tsv", 
+    "md5_checksum": "f6230d3d3eadab80074ecfe59a623c10", 
+    "file_size_bytes": 9207874, 
+    "id": "nmdc:f6230d3d3eadab80074ecfe59a623c10", 
+    "name": "gold:Gp0115672_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115672", 
+    "url": "https://data.microbiomedata.org/1781_86103/img_annotation/Ga0482255_functional_annotation.gff", 
+    "md5_checksum": "5c1afd4ffb1b1594807fbd0901da7a88", 
+    "file_size_bytes": 71214958, 
+    "id": "nmdc:5c1afd4ffb1b1594807fbd0901da7a88", 
+    "name": "gold:Gp0115672_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115672", 
+    "url": "https://data.microbiomedata.org/1781_86103/img_annotation/Ga0482255_proteins.faa", 
+    "md5_checksum": "b0687d58e2803a41864c9d830977402b", 
+    "file_size_bytes": 68196449, 
+    "id": "nmdc:b0687d58e2803a41864c9d830977402b", 
+    "name": "gold:Gp0115672_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115672", 
+    "url": "https://data.microbiomedata.org/1781_86103/img_annotation/Ga0482255_structural_annotation.gff", 
+    "md5_checksum": "644d67586f9337bf4d12ff5859d4cd54", 
+    "file_size_bytes": 37496059, 
+    "id": "nmdc:644d67586f9337bf4d12ff5859d4cd54", 
+    "name": "gold:Gp0115672_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115674", 
+    "url": "https://data.microbiomedata.org/1781_86104/img_annotation/Ga0482253_ec.tsv", 
+    "md5_checksum": "72ede7603b72206d929c03364769021c", 
+    "file_size_bytes": 3583420, 
+    "id": "nmdc:72ede7603b72206d929c03364769021c", 
+    "name": "gold:Gp0115674_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115674", 
+    "url": "https://data.microbiomedata.org/1781_86104/img_annotation/Ga0482253_ko.tsv", 
+    "md5_checksum": "9c248ab2a22c7b49060e544f37b9c798", 
+    "file_size_bytes": 5596918, 
+    "id": "nmdc:9c248ab2a22c7b49060e544f37b9c798", 
+    "name": "gold:Gp0115674_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115674", 
+    "url": "https://data.microbiomedata.org/1781_86104/img_annotation/Ga0482253_functional_annotation.gff", 
+    "md5_checksum": "876382e7107a83b87a059e4e961bff75", 
+    "file_size_bytes": 43432251, 
+    "id": "nmdc:876382e7107a83b87a059e4e961bff75", 
+    "name": "gold:Gp0115674_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115674", 
+    "url": "https://data.microbiomedata.org/1781_86104/img_annotation/Ga0482253_proteins.faa", 
+    "md5_checksum": "c70d6973abeb3ee231d3e38c3c5dced4", 
+    "file_size_bytes": 41594824, 
+    "id": "nmdc:c70d6973abeb3ee231d3e38c3c5dced4", 
+    "name": "gold:Gp0115674_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115674", 
+    "url": "https://data.microbiomedata.org/1781_86104/img_annotation/Ga0482253_structural_annotation.gff", 
+    "md5_checksum": "17f2fbdeb3f5891c37f2e9e43a40c7b1", 
+    "file_size_bytes": 22942151, 
+    "id": "nmdc:17f2fbdeb3f5891c37f2e9e43a40c7b1", 
+    "name": "gold:Gp0115674_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0115679", 
+    "url": "https://data.microbiomedata.org/1781_86105/img_annotation/Ga0482248_ec.tsv", 
+    "md5_checksum": "aa5fa1b83592459bd3e742be4949d0b1", 
+    "file_size_bytes": 10292375, 
+    "id": "nmdc:aa5fa1b83592459bd3e742be4949d0b1", 
+    "name": "gold:Gp0115679_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0115679", 
+    "url": "https://data.microbiomedata.org/1781_86105/img_annotation/Ga0482248_ko.tsv", 
+    "md5_checksum": "ee75eaed19b9a259e0e70e20a53f7fba", 
+    "file_size_bytes": 15565370, 
+    "id": "nmdc:ee75eaed19b9a259e0e70e20a53f7fba", 
+    "name": "gold:Gp0115679_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0115679", 
+    "url": "https://data.microbiomedata.org/1781_86105/img_annotation/Ga0482248_functional_annotation.gff", 
+    "md5_checksum": "b8c895face8e8e77bbfc7163c7eb7850", 
+    "file_size_bytes": 150509431, 
+    "id": "nmdc:b8c895face8e8e77bbfc7163c7eb7850", 
+    "name": "gold:Gp0115679_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0115679", 
+    "url": "https://data.microbiomedata.org/1781_86105/img_annotation/Ga0482248_proteins.faa", 
+    "md5_checksum": "21f3d777493f87403b60a4a1b3dd2f1b", 
+    "file_size_bytes": 143197581, 
+    "id": "nmdc:21f3d777493f87403b60a4a1b3dd2f1b", 
+    "name": "gold:Gp0115679_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0115679", 
+    "url": "https://data.microbiomedata.org/1781_86105/img_annotation/Ga0482248_structural_annotation.gff", 
+    "md5_checksum": "b63b42c7892b4a14e5661bca5bfa2419", 
+    "file_size_bytes": 82495835, 
+    "id": "nmdc:b63b42c7892b4a14e5661bca5bfa2419", 
+    "name": "gold:Gp0115679_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321263", 
+    "url": "https://data.microbiomedata.org/503568_186507/img_annotation/Ga0482214_ec.tsv", 
+    "md5_checksum": "0c9d8d131453a814cc825668d7c18987", 
+    "file_size_bytes": 35579523, 
+    "id": "nmdc:0c9d8d131453a814cc825668d7c18987", 
+    "name": "gold:Gp0321263_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321263", 
+    "url": "https://data.microbiomedata.org/503568_186507/img_annotation/Ga0482214_ko.tsv", 
+    "md5_checksum": "cd0dca213375e3c8b0266932dfff5bb6", 
+    "file_size_bytes": 51267032, 
+    "id": "nmdc:cd0dca213375e3c8b0266932dfff5bb6", 
+    "name": "gold:Gp0321263_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321263", 
+    "url": "https://data.microbiomedata.org/503568_186507/img_annotation/Ga0482214_functional_annotation.gff", 
+    "md5_checksum": "a487ead0b28de8ac44169345638c140c", 
+    "file_size_bytes": 437276857, 
+    "id": "nmdc:a487ead0b28de8ac44169345638c140c", 
+    "name": "gold:Gp0321263_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321263", 
+    "url": "https://data.microbiomedata.org/503568_186507/img_annotation/Ga0482214_proteins.faa", 
+    "md5_checksum": "1d25e5266e86688b9e65764a9f181e27", 
+    "file_size_bytes": 403240659, 
+    "id": "nmdc:1d25e5266e86688b9e65764a9f181e27", 
+    "name": "gold:Gp0321263_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321263", 
+    "url": "https://data.microbiomedata.org/503568_186507/img_annotation/Ga0482214_structural_annotation.gff", 
+    "md5_checksum": "3725668a447e1c7e7e639376a1017e8f", 
+    "file_size_bytes": 233287416, 
+    "id": "nmdc:3725668a447e1c7e7e639376a1017e8f", 
+    "name": "gold:Gp0321263_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321264", 
+    "url": "https://data.microbiomedata.org/503568_186508/img_annotation/Ga0482213_ec.tsv", 
+    "md5_checksum": "3bbaf98e3147e0e0ef35aa56f99775b6", 
+    "file_size_bytes": 65716615, 
+    "id": "nmdc:3bbaf98e3147e0e0ef35aa56f99775b6", 
+    "name": "gold:Gp0321264_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321264", 
+    "url": "https://data.microbiomedata.org/503568_186508/img_annotation/Ga0482213_ko.tsv", 
+    "md5_checksum": "035b62005530d9f9927da7ac7b9d4407", 
+    "file_size_bytes": 94971953, 
+    "id": "nmdc:035b62005530d9f9927da7ac7b9d4407", 
+    "name": "gold:Gp0321264_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321264", 
+    "url": "https://data.microbiomedata.org/503568_186508/img_annotation/Ga0482213_functional_annotation.gff", 
+    "md5_checksum": "a76306b513c2c244bf2899284eed67c4", 
+    "file_size_bytes": 836869119, 
+    "id": "nmdc:a76306b513c2c244bf2899284eed67c4", 
+    "name": "gold:Gp0321264_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321264", 
+    "url": "https://data.microbiomedata.org/503568_186508/img_annotation/Ga0482213_proteins.faa", 
+    "md5_checksum": "409f86c6fccbe946bc56108427b01108", 
+    "file_size_bytes": 821954363, 
+    "id": "nmdc:409f86c6fccbe946bc56108427b01108", 
+    "name": "gold:Gp0321264_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321264", 
+    "url": "https://data.microbiomedata.org/503568_186508/img_annotation/Ga0482213_structural_annotation.gff", 
+    "md5_checksum": "e4e0da015bbaafeb9199ad669ae71702", 
+    "file_size_bytes": 446043536, 
+    "id": "nmdc:e4e0da015bbaafeb9199ad669ae71702", 
+    "name": "gold:Gp0321264_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321265", 
+    "url": "https://data.microbiomedata.org/503568_186509/img_annotation/Ga0482212_ec.tsv", 
+    "md5_checksum": "175f44d76765b2555c0e94e5f05fd3a1", 
+    "file_size_bytes": 58108668, 
+    "id": "nmdc:175f44d76765b2555c0e94e5f05fd3a1", 
+    "name": "gold:Gp0321265_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321265", 
+    "url": "https://data.microbiomedata.org/503568_186509/img_annotation/Ga0482212_ko.tsv", 
+    "md5_checksum": "63a567ada447f75cfc2c7fd2d45f8a39", 
+    "file_size_bytes": 84681855, 
+    "id": "nmdc:63a567ada447f75cfc2c7fd2d45f8a39", 
+    "name": "gold:Gp0321265_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321265", 
+    "url": "https://data.microbiomedata.org/503568_186509/img_annotation/Ga0482212_functional_annotation.gff", 
+    "md5_checksum": "f4aaf8a82d86aa0273b984ffb1c52dd6", 
+    "file_size_bytes": 763993890, 
+    "id": "nmdc:f4aaf8a82d86aa0273b984ffb1c52dd6", 
+    "name": "gold:Gp0321265_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321265", 
+    "url": "https://data.microbiomedata.org/503568_186509/img_annotation/Ga0482212_proteins.faa", 
+    "md5_checksum": "1de4cc65fa1e329eccf2cc9982b126aa", 
+    "file_size_bytes": 758568499, 
+    "id": "nmdc:1de4cc65fa1e329eccf2cc9982b126aa", 
+    "name": "gold:Gp0321265_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321265", 
+    "url": "https://data.microbiomedata.org/503568_186509/img_annotation/Ga0482212_structural_annotation.gff", 
+    "md5_checksum": "b91dc0c20caa465338c63c01e2c1328c", 
+    "file_size_bytes": 408052221, 
+    "id": "nmdc:b91dc0c20caa465338c63c01e2c1328c", 
+    "name": "gold:Gp0321265_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321266", 
+    "url": "https://data.microbiomedata.org/503568_186510/img_annotation/Ga0482211_ec.tsv", 
+    "md5_checksum": "0448dc8c7da28b362275a213adfaeaf6", 
+    "file_size_bytes": 33159354, 
+    "id": "nmdc:0448dc8c7da28b362275a213adfaeaf6", 
+    "name": "gold:Gp0321266_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321266", 
+    "url": "https://data.microbiomedata.org/503568_186510/img_annotation/Ga0482211_ko.tsv", 
+    "md5_checksum": "8314866bf8dc46a8934cf8b193e21b2e", 
+    "file_size_bytes": 47620743, 
+    "id": "nmdc:8314866bf8dc46a8934cf8b193e21b2e", 
+    "name": "gold:Gp0321266_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321266", 
+    "url": "https://data.microbiomedata.org/503568_186510/img_annotation/Ga0482211_functional_annotation.gff", 
+    "md5_checksum": "422fda8c954e7ffc99883d561fb6f75b", 
+    "file_size_bytes": 381902394, 
+    "id": "nmdc:422fda8c954e7ffc99883d561fb6f75b", 
+    "name": "gold:Gp0321266_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321266", 
+    "url": "https://data.microbiomedata.org/503568_186510/img_annotation/Ga0482211_proteins.faa", 
+    "md5_checksum": "a98cf4ad6cc56d5a1992c1c5b8027525", 
+    "file_size_bytes": 340716179, 
+    "id": "nmdc:a98cf4ad6cc56d5a1992c1c5b8027525", 
+    "name": "gold:Gp0321266_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321266", 
+    "url": "https://data.microbiomedata.org/503568_186510/img_annotation/Ga0482211_structural_annotation.gff", 
+    "md5_checksum": "e19fcc4f4eeb2ebaa6deec9f53e1e2d7", 
+    "file_size_bytes": 202987058, 
+    "id": "nmdc:e19fcc4f4eeb2ebaa6deec9f53e1e2d7", 
+    "name": "gold:Gp0321266_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321267", 
+    "url": "https://data.microbiomedata.org/503568_186511/img_annotation/Ga0482210_ec.tsv", 
+    "md5_checksum": "8c46e28d633eb9243f9edd0368a66f44", 
+    "file_size_bytes": 58457188, 
+    "id": "nmdc:8c46e28d633eb9243f9edd0368a66f44", 
+    "name": "gold:Gp0321267_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321267", 
+    "url": "https://data.microbiomedata.org/503568_186511/img_annotation/Ga0482210_ko.tsv", 
+    "md5_checksum": "9cb8fdc5cd7bd605f3fcff2ea39cfbf5", 
+    "file_size_bytes": 85138878, 
+    "id": "nmdc:9cb8fdc5cd7bd605f3fcff2ea39cfbf5", 
+    "name": "gold:Gp0321267_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321267", 
+    "url": "https://data.microbiomedata.org/503568_186511/img_annotation/Ga0482210_functional_annotation.gff", 
+    "md5_checksum": "e2708c2679b2002486bb6c4cc1fcc1f1", 
+    "file_size_bytes": 739043657, 
+    "id": "nmdc:e2708c2679b2002486bb6c4cc1fcc1f1", 
+    "name": "gold:Gp0321267_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321267", 
+    "url": "https://data.microbiomedata.org/503568_186511/img_annotation/Ga0482210_proteins.faa", 
+    "md5_checksum": "716d26a135a99c9efc8c49d4b294f8e8", 
+    "file_size_bytes": 701129929, 
+    "id": "nmdc:716d26a135a99c9efc8c49d4b294f8e8", 
+    "name": "gold:Gp0321267_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321267", 
+    "url": "https://data.microbiomedata.org/503568_186511/img_annotation/Ga0482210_structural_annotation.gff", 
+    "md5_checksum": "ff9b33e360b07cf16501e4002cceb1a3", 
+    "file_size_bytes": 395904257, 
+    "id": "nmdc:ff9b33e360b07cf16501e4002cceb1a3", 
+    "name": "gold:Gp0321267_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321268", 
+    "url": "https://data.microbiomedata.org/503568_186512/img_annotation/Ga0482209_ec.tsv", 
+    "md5_checksum": "c530c02506fb7f4c0e90eaa46ef931f9", 
+    "file_size_bytes": 58026513, 
+    "id": "nmdc:c530c02506fb7f4c0e90eaa46ef931f9", 
+    "name": "gold:Gp0321268_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321268", 
+    "url": "https://data.microbiomedata.org/503568_186512/img_annotation/Ga0482209_ko.tsv", 
+    "md5_checksum": "9047db5ed7d535f7a8cf238feea4112e", 
+    "file_size_bytes": 84651305, 
+    "id": "nmdc:9047db5ed7d535f7a8cf238feea4112e", 
+    "name": "gold:Gp0321268_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321268", 
+    "url": "https://data.microbiomedata.org/503568_186512/img_annotation/Ga0482209_functional_annotation.gff", 
+    "md5_checksum": "d8e3a237e08fe7b14816ed38cb15f7e5", 
+    "file_size_bytes": 753270835, 
+    "id": "nmdc:d8e3a237e08fe7b14816ed38cb15f7e5", 
+    "name": "gold:Gp0321268_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321268", 
+    "url": "https://data.microbiomedata.org/503568_186512/img_annotation/Ga0482209_proteins.faa", 
+    "md5_checksum": "313edf6edf574cd30a06f3695c98c0fe", 
+    "file_size_bytes": 725403413, 
+    "id": "nmdc:313edf6edf574cd30a06f3695c98c0fe", 
+    "name": "gold:Gp0321268_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321268", 
+    "url": "https://data.microbiomedata.org/503568_186512/img_annotation/Ga0482209_structural_annotation.gff", 
+    "md5_checksum": "8ebacf3cb9208f5788c4a664e2bb6155", 
+    "file_size_bytes": 403988177, 
+    "id": "nmdc:8ebacf3cb9208f5788c4a664e2bb6155", 
+    "name": "gold:Gp0321268_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321269", 
+    "url": "https://data.microbiomedata.org/503568_186513/img_annotation/Ga0482208_ec.tsv", 
+    "md5_checksum": "d110ababa05ffea4c73fd7f6c2823a01", 
+    "file_size_bytes": 69534434, 
+    "id": "nmdc:d110ababa05ffea4c73fd7f6c2823a01", 
+    "name": "gold:Gp0321269_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321269", 
+    "url": "https://data.microbiomedata.org/503568_186513/img_annotation/Ga0482208_ko.tsv", 
+    "md5_checksum": "0edba9c3bac0163e9ee8d3acc138f0be", 
+    "file_size_bytes": 101110372, 
+    "id": "nmdc:0edba9c3bac0163e9ee8d3acc138f0be", 
+    "name": "gold:Gp0321269_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321269", 
+    "url": "https://data.microbiomedata.org/503568_186513/img_annotation/Ga0482208_functional_annotation.gff", 
+    "md5_checksum": "920ffe0caa9796066c6dc232ca29e4bf", 
+    "file_size_bytes": 880670191, 
+    "id": "nmdc:920ffe0caa9796066c6dc232ca29e4bf", 
+    "name": "gold:Gp0321269_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321269", 
+    "url": "https://data.microbiomedata.org/503568_186513/img_annotation/Ga0482208_proteins.faa", 
+    "md5_checksum": "8036d9e860e7c6ac63d62389b012cc39", 
+    "file_size_bytes": 869458999, 
+    "id": "nmdc:8036d9e860e7c6ac63d62389b012cc39", 
+    "name": "gold:Gp0321269_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321269", 
+    "url": "https://data.microbiomedata.org/503568_186513/img_annotation/Ga0482208_structural_annotation.gff", 
+    "md5_checksum": "1eebc50c86e6e560d910b68358c76117", 
+    "file_size_bytes": 468770466, 
+    "id": "nmdc:1eebc50c86e6e560d910b68358c76117", 
+    "name": "gold:Gp0321269_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321270", 
+    "url": "https://data.microbiomedata.org/503568_186514/img_annotation/Ga0482207_ec.tsv", 
+    "md5_checksum": "513baf8db74eaf64d7aa7698f1cf31b7", 
+    "file_size_bytes": 49447071, 
+    "id": "nmdc:513baf8db74eaf64d7aa7698f1cf31b7", 
+    "name": "gold:Gp0321270_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321270", 
+    "url": "https://data.microbiomedata.org/503568_186514/img_annotation/Ga0482207_ko.tsv", 
+    "md5_checksum": "e9a333448ef41a27086e8df2b1ba6476", 
+    "file_size_bytes": 71574979, 
+    "id": "nmdc:e9a333448ef41a27086e8df2b1ba6476", 
+    "name": "gold:Gp0321270_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321270", 
+    "url": "https://data.microbiomedata.org/503568_186514/img_annotation/Ga0482207_functional_annotation.gff", 
+    "md5_checksum": "488174c4683c9fe45eae35664a4f7774", 
+    "file_size_bytes": 602939771, 
+    "id": "nmdc:488174c4683c9fe45eae35664a4f7774", 
+    "name": "gold:Gp0321270_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321270", 
+    "url": "https://data.microbiomedata.org/503568_186514/img_annotation/Ga0482207_proteins.faa", 
+    "md5_checksum": "f76b4199f7c1a19bbec3f8a3c39967c8", 
+    "file_size_bytes": 558874966, 
+    "id": "nmdc:f76b4199f7c1a19bbec3f8a3c39967c8", 
+    "name": "gold:Gp0321270_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321270", 
+    "url": "https://data.microbiomedata.org/503568_186514/img_annotation/Ga0482207_structural_annotation.gff", 
+    "md5_checksum": "d325fdb48d28bb5e04b261496c897a80", 
+    "file_size_bytes": 323096741, 
+    "id": "nmdc:d325fdb48d28bb5e04b261496c897a80", 
+    "name": "gold:Gp0321270_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321271", 
+    "url": "https://data.microbiomedata.org/503568_186515/img_annotation/Ga0482206_ec.tsv", 
+    "md5_checksum": "55982ed44eeba03a461a3b837f8344d8", 
+    "file_size_bytes": 56130157, 
+    "id": "nmdc:55982ed44eeba03a461a3b837f8344d8", 
+    "name": "gold:Gp0321271_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321271", 
+    "url": "https://data.microbiomedata.org/503568_186515/img_annotation/Ga0482206_ko.tsv", 
+    "md5_checksum": "ede2997cb8cb2cdd14d9aa415157ecdd", 
+    "file_size_bytes": 80978900, 
+    "id": "nmdc:ede2997cb8cb2cdd14d9aa415157ecdd", 
+    "name": "gold:Gp0321271_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321271", 
+    "url": "https://data.microbiomedata.org/503568_186515/img_annotation/Ga0482206_functional_annotation.gff", 
+    "md5_checksum": "1e90bfe885aac91db1abd71c03ff283c", 
+    "file_size_bytes": 691843895, 
+    "id": "nmdc:1e90bfe885aac91db1abd71c03ff283c", 
+    "name": "gold:Gp0321271_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321271", 
+    "url": "https://data.microbiomedata.org/503568_186515/img_annotation/Ga0482206_proteins.faa", 
+    "md5_checksum": "1492b148b7432379040c78f4b1d84eed", 
+    "file_size_bytes": 670946896, 
+    "id": "nmdc:1492b148b7432379040c78f4b1d84eed", 
+    "name": "gold:Gp0321271_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321271", 
+    "url": "https://data.microbiomedata.org/503568_186515/img_annotation/Ga0482206_structural_annotation.gff", 
+    "md5_checksum": "d5241932493adac238e254fe0ea0b1b3", 
+    "file_size_bytes": 367479238, 
+    "id": "nmdc:d5241932493adac238e254fe0ea0b1b3", 
+    "name": "gold:Gp0321271_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321272", 
+    "url": "https://data.microbiomedata.org/503568_186516/img_annotation/Ga0482205_ec.tsv", 
+    "md5_checksum": "18bc1ef31ea841c4eb135a4598d4643e", 
+    "file_size_bytes": 34971034, 
+    "id": "nmdc:18bc1ef31ea841c4eb135a4598d4643e", 
+    "name": "gold:Gp0321272_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321272", 
+    "url": "https://data.microbiomedata.org/503568_186516/img_annotation/Ga0482205_ko.tsv", 
+    "md5_checksum": "e20aeed82d3c566fcc454be8dcb30a48", 
+    "file_size_bytes": 51618071, 
+    "id": "nmdc:e20aeed82d3c566fcc454be8dcb30a48", 
+    "name": "gold:Gp0321272_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321272", 
+    "url": "https://data.microbiomedata.org/503568_186516/img_annotation/Ga0482205_functional_annotation.gff", 
+    "md5_checksum": "f5dc696f69438dcbaa2c5c1685db322e", 
+    "file_size_bytes": 436370856, 
+    "id": "nmdc:f5dc696f69438dcbaa2c5c1685db322e", 
+    "name": "gold:Gp0321272_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321272", 
+    "url": "https://data.microbiomedata.org/503568_186516/img_annotation/Ga0482205_proteins.faa", 
+    "md5_checksum": "311a2b8d368d7f20869eb709f6a2fbca", 
+    "file_size_bytes": 416639628, 
+    "id": "nmdc:311a2b8d368d7f20869eb709f6a2fbca", 
+    "name": "gold:Gp0321272_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321272", 
+    "url": "https://data.microbiomedata.org/503568_186516/img_annotation/Ga0482205_structural_annotation.gff", 
+    "md5_checksum": "456ee70f5d3428e1a1326bf3b3a3f45b", 
+    "file_size_bytes": 232384536, 
+    "id": "nmdc:456ee70f5d3428e1a1326bf3b3a3f45b", 
+    "name": "gold:Gp0321272_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321273", 
+    "url": "https://data.microbiomedata.org/503568_186517/img_annotation/Ga0482204_ec.tsv", 
+    "md5_checksum": "bfa6d313b084b76f378fe23e58693729", 
+    "file_size_bytes": 53685585, 
+    "id": "nmdc:bfa6d313b084b76f378fe23e58693729", 
+    "name": "gold:Gp0321273_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321273", 
+    "url": "https://data.microbiomedata.org/503568_186517/img_annotation/Ga0482204_ko.tsv", 
+    "md5_checksum": "cd1b72215cb87dcc9f582a4b42ba39e2", 
+    "file_size_bytes": 78930288, 
+    "id": "nmdc:cd1b72215cb87dcc9f582a4b42ba39e2", 
+    "name": "gold:Gp0321273_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321273", 
+    "url": "https://data.microbiomedata.org/503568_186517/img_annotation/Ga0482204_functional_annotation.gff", 
+    "md5_checksum": "edd6a05489d203f580a0c8b4db6f239b", 
+    "file_size_bytes": 689428171, 
+    "id": "nmdc:edd6a05489d203f580a0c8b4db6f239b", 
+    "name": "gold:Gp0321273_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321273", 
+    "url": "https://data.microbiomedata.org/503568_186517/img_annotation/Ga0482204_proteins.faa", 
+    "md5_checksum": "fd5fd05a55dad39734cb7845be8f1455", 
+    "file_size_bytes": 656392957, 
+    "id": "nmdc:fd5fd05a55dad39734cb7845be8f1455", 
+    "name": "gold:Gp0321273_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321273", 
+    "url": "https://data.microbiomedata.org/503568_186517/img_annotation/Ga0482204_structural_annotation.gff", 
+    "md5_checksum": "f6c682e41266abf2a82301cee11ecc2c", 
+    "file_size_bytes": 369256543, 
+    "id": "nmdc:f6c682e41266abf2a82301cee11ecc2c", 
+    "name": "gold:Gp0321273_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321274", 
+    "url": "https://data.microbiomedata.org/503568_186518/img_annotation/Ga0482203_ec.tsv", 
+    "md5_checksum": "75c5338fc5735f215fbff0c0a7ea89f7", 
+    "file_size_bytes": 47197597, 
+    "id": "nmdc:75c5338fc5735f215fbff0c0a7ea89f7", 
+    "name": "gold:Gp0321274_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321274", 
+    "url": "https://data.microbiomedata.org/503568_186518/img_annotation/Ga0482203_ko.tsv", 
+    "md5_checksum": "451db12e17920c73990ed6019cffb75e", 
+    "file_size_bytes": 69154136, 
+    "id": "nmdc:451db12e17920c73990ed6019cffb75e", 
+    "name": "gold:Gp0321274_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321274", 
+    "url": "https://data.microbiomedata.org/503568_186518/img_annotation/Ga0482203_functional_annotation.gff", 
+    "md5_checksum": "7c860f38be54584abbf65b05d023ab9b", 
+    "file_size_bytes": 602503801, 
+    "id": "nmdc:7c860f38be54584abbf65b05d023ab9b", 
+    "name": "gold:Gp0321274_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321274", 
+    "url": "https://data.microbiomedata.org/503568_186518/img_annotation/Ga0482203_proteins.faa", 
+    "md5_checksum": "880903dfa10de6c316ea4b5648c65022", 
+    "file_size_bytes": 586711000, 
+    "id": "nmdc:880903dfa10de6c316ea4b5648c65022", 
+    "name": "gold:Gp0321274_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321274", 
+    "url": "https://data.microbiomedata.org/503568_186518/img_annotation/Ga0482203_structural_annotation.gff", 
+    "md5_checksum": "28399ee3579aabdd7a96181a85a36b08", 
+    "file_size_bytes": 320500903, 
+    "id": "nmdc:28399ee3579aabdd7a96181a85a36b08", 
+    "name": "gold:Gp0321274_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321275", 
+    "url": "https://data.microbiomedata.org/503568_186519/img_annotation/Ga0482202_ec.tsv", 
+    "md5_checksum": "b134b99e3681cb2f6882d70e0505a295", 
+    "file_size_bytes": 59409123, 
+    "id": "nmdc:b134b99e3681cb2f6882d70e0505a295", 
+    "name": "gold:Gp0321275_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321275", 
+    "url": "https://data.microbiomedata.org/503568_186519/img_annotation/Ga0482202_ko.tsv", 
+    "md5_checksum": "a94304d7af292aefec5fbeb0bcbb7685", 
+    "file_size_bytes": 86258757, 
+    "id": "nmdc:a94304d7af292aefec5fbeb0bcbb7685", 
+    "name": "gold:Gp0321275_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321275", 
+    "url": "https://data.microbiomedata.org/503568_186519/img_annotation/Ga0482202_functional_annotation.gff", 
+    "md5_checksum": "4d8a2a87ea74daac3495c512fd96d96c", 
+    "file_size_bytes": 719614523, 
+    "id": "nmdc:4d8a2a87ea74daac3495c512fd96d96c", 
+    "name": "gold:Gp0321275_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321275", 
+    "url": "https://data.microbiomedata.org/503568_186519/img_annotation/Ga0482202_proteins.faa", 
+    "md5_checksum": "ad8da930414a7a388eb050a8b6fc089f", 
+    "file_size_bytes": 691111579, 
+    "id": "nmdc:ad8da930414a7a388eb050a8b6fc089f", 
+    "name": "gold:Gp0321275_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321275", 
+    "url": "https://data.microbiomedata.org/503568_186519/img_annotation/Ga0482202_structural_annotation.gff", 
+    "md5_checksum": "6f23809a438fa0ab8784393345dd9485", 
+    "file_size_bytes": 383739993, 
+    "id": "nmdc:6f23809a438fa0ab8784393345dd9485", 
+    "name": "gold:Gp0321275_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321276", 
+    "url": "https://data.microbiomedata.org/503568_186520/img_annotation/Ga0482201_ec.tsv", 
+    "md5_checksum": "1195d877af5d70a04d1af414939fe76a", 
+    "file_size_bytes": 55350202, 
+    "id": "nmdc:1195d877af5d70a04d1af414939fe76a", 
+    "name": "gold:Gp0321276_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321276", 
+    "url": "https://data.microbiomedata.org/503568_186520/img_annotation/Ga0482201_ko.tsv", 
+    "md5_checksum": "afa84ad89ba252703ca11305b2b45915", 
+    "file_size_bytes": 80730137, 
+    "id": "nmdc:afa84ad89ba252703ca11305b2b45915", 
+    "name": "gold:Gp0321276_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321276", 
+    "url": "https://data.microbiomedata.org/503568_186520/img_annotation/Ga0482201_functional_annotation.gff", 
+    "md5_checksum": "98f986365776814d44158c1ef6cfd5e0", 
+    "file_size_bytes": 697168835, 
+    "id": "nmdc:98f986365776814d44158c1ef6cfd5e0", 
+    "name": "gold:Gp0321276_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321276", 
+    "url": "https://data.microbiomedata.org/503568_186520/img_annotation/Ga0482201_proteins.faa", 
+    "md5_checksum": "cbfb3e7e74bb881dcb516e1d0388a9f7", 
+    "file_size_bytes": 682066142, 
+    "id": "nmdc:cbfb3e7e74bb881dcb516e1d0388a9f7", 
+    "name": "gold:Gp0321276_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321276", 
+    "url": "https://data.microbiomedata.org/503568_186520/img_annotation/Ga0482201_structural_annotation.gff", 
+    "md5_checksum": "6c84c9ba98e6d4420568ccdee2d8f0ba", 
+    "file_size_bytes": 370994825, 
+    "id": "nmdc:6c84c9ba98e6d4420568ccdee2d8f0ba", 
+    "name": "gold:Gp0321276_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321277", 
+    "url": "https://data.microbiomedata.org/503568_186521/img_annotation/Ga0482200_ec.tsv", 
+    "md5_checksum": "e78cc5ab16e013800bd4cca3a76ca314", 
+    "file_size_bytes": 47578645, 
+    "id": "nmdc:e78cc5ab16e013800bd4cca3a76ca314", 
+    "name": "gold:Gp0321277_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321277", 
+    "url": "https://data.microbiomedata.org/503568_186521/img_annotation/Ga0482200_ko.tsv", 
+    "md5_checksum": "a654d80633b26c66d4c6dd30988e3083", 
+    "file_size_bytes": 69231430, 
+    "id": "nmdc:a654d80633b26c66d4c6dd30988e3083", 
+    "name": "gold:Gp0321277_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321277", 
+    "url": "https://data.microbiomedata.org/503568_186521/img_annotation/Ga0482200_functional_annotation.gff", 
+    "md5_checksum": "7a00101741bd9366a36d6e2a60cf0345", 
+    "file_size_bytes": 598882250, 
+    "id": "nmdc:7a00101741bd9366a36d6e2a60cf0345", 
+    "name": "gold:Gp0321277_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321277", 
+    "url": "https://data.microbiomedata.org/503568_186521/img_annotation/Ga0482200_proteins.faa", 
+    "md5_checksum": "835275caf77ddcc493b4354cb4d10eab", 
+    "file_size_bytes": 584261715, 
+    "id": "nmdc:835275caf77ddcc493b4354cb4d10eab", 
+    "name": "gold:Gp0321277_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321277", 
+    "url": "https://data.microbiomedata.org/503568_186521/img_annotation/Ga0482200_structural_annotation.gff", 
+    "md5_checksum": "7222ad2fb0e606000ea88c4d22595c1b", 
+    "file_size_bytes": 317741556, 
+    "id": "nmdc:7222ad2fb0e606000ea88c4d22595c1b", 
+    "name": "gold:Gp0321277_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321278", 
+    "url": "https://data.microbiomedata.org/503568_186522/img_annotation/Ga0482199_ec.tsv", 
+    "md5_checksum": "a964f01c89dd3b6575fd1214fe021c3e", 
+    "file_size_bytes": 31666417, 
+    "id": "nmdc:a964f01c89dd3b6575fd1214fe021c3e", 
+    "name": "gold:Gp0321278_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321278", 
+    "url": "https://data.microbiomedata.org/503568_186522/img_annotation/Ga0482199_ko.tsv", 
+    "md5_checksum": "aff1f1e47e91e8df247fed3a28a6998e", 
+    "file_size_bytes": 45885447, 
+    "id": "nmdc:aff1f1e47e91e8df247fed3a28a6998e", 
+    "name": "gold:Gp0321278_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321278", 
+    "url": "https://data.microbiomedata.org/503568_186522/img_annotation/Ga0482199_functional_annotation.gff", 
+    "md5_checksum": "f620e02d2c26b5f2c0db7d77f2168e66", 
+    "file_size_bytes": 387436557, 
+    "id": "nmdc:f620e02d2c26b5f2c0db7d77f2168e66", 
+    "name": "gold:Gp0321278_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321278", 
+    "url": "https://data.microbiomedata.org/503568_186522/img_annotation/Ga0482199_proteins.faa", 
+    "md5_checksum": "2cd8a777b2b2f56a47e8f99269c2278e", 
+    "file_size_bytes": 366379396, 
+    "id": "nmdc:2cd8a777b2b2f56a47e8f99269c2278e", 
+    "name": "gold:Gp0321278_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321278", 
+    "url": "https://data.microbiomedata.org/503568_186522/img_annotation/Ga0482199_structural_annotation.gff", 
+    "md5_checksum": "36c79ccbf21d3d76d92e670e24ca0321", 
+    "file_size_bytes": 205776320, 
+    "id": "nmdc:36c79ccbf21d3d76d92e670e24ca0321", 
+    "name": "gold:Gp0321278_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321279", 
+    "url": "https://data.microbiomedata.org/503568_186523/img_annotation/Ga0482198_ec.tsv", 
+    "md5_checksum": "e93e03eb9d260a9ff4d58f10f8ce033d", 
+    "file_size_bytes": 62855248, 
+    "id": "nmdc:e93e03eb9d260a9ff4d58f10f8ce033d", 
+    "name": "gold:Gp0321279_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321279", 
+    "url": "https://data.microbiomedata.org/503568_186523/img_annotation/Ga0482198_ko.tsv", 
+    "md5_checksum": "8756ede859a2eeb165294bc60757161a", 
+    "file_size_bytes": 91393267, 
+    "id": "nmdc:8756ede859a2eeb165294bc60757161a", 
+    "name": "gold:Gp0321279_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321279", 
+    "url": "https://data.microbiomedata.org/503568_186523/img_annotation/Ga0482198_functional_annotation.gff", 
+    "md5_checksum": "32ca08ad6221ce0282f7e560d84b6bc1", 
+    "file_size_bytes": 795552383, 
+    "id": "nmdc:32ca08ad6221ce0282f7e560d84b6bc1", 
+    "name": "gold:Gp0321279_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321279", 
+    "url": "https://data.microbiomedata.org/503568_186523/img_annotation/Ga0482198_proteins.faa", 
+    "md5_checksum": "1150c8570758aea8c9b32602ac9df694", 
+    "file_size_bytes": 764663551, 
+    "id": "nmdc:1150c8570758aea8c9b32602ac9df694", 
+    "name": "gold:Gp0321279_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321279", 
+    "url": "https://data.microbiomedata.org/503568_186523/img_annotation/Ga0482198_structural_annotation.gff", 
+    "md5_checksum": "3be5100c3d71a32afbe19ba3bd9648d2", 
+    "file_size_bytes": 424918278, 
+    "id": "nmdc:3be5100c3d71a32afbe19ba3bd9648d2", 
+    "name": "gold:Gp0321279_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321280", 
+    "url": "https://data.microbiomedata.org/503568_186524/img_annotation/Ga0482197_ec.tsv", 
+    "md5_checksum": "287108afe4b88d94e576549e1053fd72", 
+    "file_size_bytes": 38550005, 
+    "id": "nmdc:287108afe4b88d94e576549e1053fd72", 
+    "name": "gold:Gp0321280_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321280", 
+    "url": "https://data.microbiomedata.org/503568_186524/img_annotation/Ga0482197_ko.tsv", 
+    "md5_checksum": "1f5cd6b40da64aad6847e6b393764ba9", 
+    "file_size_bytes": 56202646, 
+    "id": "nmdc:1f5cd6b40da64aad6847e6b393764ba9", 
+    "name": "gold:Gp0321280_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321280", 
+    "url": "https://data.microbiomedata.org/503568_186524/img_annotation/Ga0482197_functional_annotation.gff", 
+    "md5_checksum": "4541de98c3049d59ca8aed9b5dce9096", 
+    "file_size_bytes": 480963763, 
+    "id": "nmdc:4541de98c3049d59ca8aed9b5dce9096", 
+    "name": "gold:Gp0321280_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321280", 
+    "url": "https://data.microbiomedata.org/503568_186524/img_annotation/Ga0482197_proteins.faa", 
+    "md5_checksum": "ca620fc038f51501e1dd5af9bf085231", 
+    "file_size_bytes": 466945329, 
+    "id": "nmdc:ca620fc038f51501e1dd5af9bf085231", 
+    "name": "gold:Gp0321280_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321280", 
+    "url": "https://data.microbiomedata.org/503568_186524/img_annotation/Ga0482197_structural_annotation.gff", 
+    "md5_checksum": "20def41369f21c85f890c13663dc7c38", 
+    "file_size_bytes": 254608862, 
+    "id": "nmdc:20def41369f21c85f890c13663dc7c38", 
+    "name": "gold:Gp0321280_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321281", 
+    "url": "https://data.microbiomedata.org/503568_186525/img_annotation/Ga0482196_ec.tsv", 
+    "md5_checksum": "aaacc4e710bee5cd3dcf0373126df7df", 
+    "file_size_bytes": 59111040, 
+    "id": "nmdc:aaacc4e710bee5cd3dcf0373126df7df", 
+    "name": "gold:Gp0321281_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321281", 
+    "url": "https://data.microbiomedata.org/503568_186525/img_annotation/Ga0482196_ko.tsv", 
+    "md5_checksum": "7fb1738c852a309fba1fbc2d608da042", 
+    "file_size_bytes": 86093702, 
+    "id": "nmdc:7fb1738c852a309fba1fbc2d608da042", 
+    "name": "gold:Gp0321281_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321281", 
+    "url": "https://data.microbiomedata.org/503568_186525/img_annotation/Ga0482196_functional_annotation.gff", 
+    "md5_checksum": "37e76dc62740e3e9cde6fd0ac56fd149", 
+    "file_size_bytes": 716739952, 
+    "id": "nmdc:37e76dc62740e3e9cde6fd0ac56fd149", 
+    "name": "gold:Gp0321281_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321281", 
+    "url": "https://data.microbiomedata.org/503568_186525/img_annotation/Ga0482196_proteins.faa", 
+    "md5_checksum": "27eb4ee0689bfa1ed5de639be9dfe4a4", 
+    "file_size_bytes": 673075685, 
+    "id": "nmdc:27eb4ee0689bfa1ed5de639be9dfe4a4", 
+    "name": "gold:Gp0321281_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321281", 
+    "url": "https://data.microbiomedata.org/503568_186525/img_annotation/Ga0482196_structural_annotation.gff", 
+    "md5_checksum": "5adfd50423654d4ee2a7ea1cb047903b", 
+    "file_size_bytes": 383484568, 
+    "id": "nmdc:5adfd50423654d4ee2a7ea1cb047903b", 
+    "name": "gold:Gp0321281_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321282", 
+    "url": "https://data.microbiomedata.org/503568_186526/img_annotation/Ga0482195_ec.tsv", 
+    "md5_checksum": "59a2715743627c1746e93b3c4737c7a1", 
+    "file_size_bytes": 37947446, 
+    "id": "nmdc:59a2715743627c1746e93b3c4737c7a1", 
+    "name": "gold:Gp0321282_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321282", 
+    "url": "https://data.microbiomedata.org/503568_186526/img_annotation/Ga0482195_ko.tsv", 
+    "md5_checksum": "18957818ea8c9b81ca7cc6b051109f98", 
+    "file_size_bytes": 55100248, 
+    "id": "nmdc:18957818ea8c9b81ca7cc6b051109f98", 
+    "name": "gold:Gp0321282_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321282", 
+    "url": "https://data.microbiomedata.org/503568_186526/img_annotation/Ga0482195_functional_annotation.gff", 
+    "md5_checksum": "2fe451504079842f4aed6fc3fc4234f0", 
+    "file_size_bytes": 472444074, 
+    "id": "nmdc:2fe451504079842f4aed6fc3fc4234f0", 
+    "name": "gold:Gp0321282_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321282", 
+    "url": "https://data.microbiomedata.org/503568_186526/img_annotation/Ga0482195_proteins.faa", 
+    "md5_checksum": "b4785d3de1e96579a0139fd62b46c2b1", 
+    "file_size_bytes": 446819588, 
+    "id": "nmdc:b4785d3de1e96579a0139fd62b46c2b1", 
+    "name": "gold:Gp0321282_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321282", 
+    "url": "https://data.microbiomedata.org/503568_186526/img_annotation/Ga0482195_structural_annotation.gff", 
+    "md5_checksum": "64eb490c848063b2d2ec3a67e25e9fc0", 
+    "file_size_bytes": 251715266, 
+    "id": "nmdc:64eb490c848063b2d2ec3a67e25e9fc0", 
+    "name": "gold:Gp0321282_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321283", 
+    "url": "https://data.microbiomedata.org/503568_186527/img_annotation/Ga0482194_ec.tsv", 
+    "md5_checksum": "3a1dcb36da8d2a8e0bd75839eb87ea92", 
+    "file_size_bytes": 82531665, 
+    "id": "nmdc:3a1dcb36da8d2a8e0bd75839eb87ea92", 
+    "name": "gold:Gp0321283_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321283", 
+    "url": "https://data.microbiomedata.org/503568_186527/img_annotation/Ga0482194_ko.tsv", 
+    "md5_checksum": "b609fcbf134b41436694f56d0206e33d", 
+    "file_size_bytes": 120479344, 
+    "id": "nmdc:b609fcbf134b41436694f56d0206e33d", 
+    "name": "gold:Gp0321283_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321283", 
+    "url": "https://data.microbiomedata.org/503568_186527/img_annotation/Ga0482194_functional_annotation.gff", 
+    "md5_checksum": "50bc1b45ffe95d3def7b0acc0652082f", 
+    "file_size_bytes": 1064569128, 
+    "id": "nmdc:50bc1b45ffe95d3def7b0acc0652082f", 
+    "name": "gold:Gp0321283_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321283", 
+    "url": "https://data.microbiomedata.org/503568_186527/img_annotation/Ga0482194_proteins.faa", 
+    "md5_checksum": "371a4bc8b331c5a58f5eae72aa7f2ef2", 
+    "file_size_bytes": 1053474808, 
+    "id": "nmdc:371a4bc8b331c5a58f5eae72aa7f2ef2", 
+    "name": "gold:Gp0321283_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321283", 
+    "url": "https://data.microbiomedata.org/503568_186527/img_annotation/Ga0482194_structural_annotation.gff", 
+    "md5_checksum": "dae48dbf003f88ae694fa4461cce315d", 
+    "file_size_bytes": 569086929, 
+    "id": "nmdc:dae48dbf003f88ae694fa4461cce315d", 
+    "name": "gold:Gp0321283_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321284", 
+    "url": "https://data.microbiomedata.org/503568_186528/img_annotation/Ga0482193_ec.tsv", 
+    "md5_checksum": "3760f2f322ccb7bd25bd9e73529e4bc0", 
+    "file_size_bytes": 54966247, 
+    "id": "nmdc:3760f2f322ccb7bd25bd9e73529e4bc0", 
+    "name": "gold:Gp0321284_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321284", 
+    "url": "https://data.microbiomedata.org/503568_186528/img_annotation/Ga0482193_ko.tsv", 
+    "md5_checksum": "46f93869937443dd0c5c75e22877cb49", 
+    "file_size_bytes": 79648910, 
+    "id": "nmdc:46f93869937443dd0c5c75e22877cb49", 
+    "name": "gold:Gp0321284_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321284", 
+    "url": "https://data.microbiomedata.org/503568_186528/img_annotation/Ga0482193_functional_annotation.gff", 
+    "md5_checksum": "0f5d384d0a5394fec7546cd4a16dc5cb", 
+    "file_size_bytes": 667542858, 
+    "id": "nmdc:0f5d384d0a5394fec7546cd4a16dc5cb", 
+    "name": "gold:Gp0321284_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321284", 
+    "url": "https://data.microbiomedata.org/503568_186528/img_annotation/Ga0482193_proteins.faa", 
+    "md5_checksum": "73c7f3cc99686ec1e603fa63596b904f", 
+    "file_size_bytes": 636797625, 
+    "id": "nmdc:73c7f3cc99686ec1e603fa63596b904f", 
+    "name": "gold:Gp0321284_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321284", 
+    "url": "https://data.microbiomedata.org/503568_186528/img_annotation/Ga0482193_structural_annotation.gff", 
+    "md5_checksum": "79216bdd4f78c73571a7eba424e10b4c", 
+    "file_size_bytes": 356103253, 
+    "id": "nmdc:79216bdd4f78c73571a7eba424e10b4c", 
+    "name": "gold:Gp0321284_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321285", 
+    "url": "https://data.microbiomedata.org/503568_186529/img_annotation/Ga0482192_ec.tsv", 
+    "md5_checksum": "fc6955e36b421ec712ba81c97c4c4e93", 
+    "file_size_bytes": 38503129, 
+    "id": "nmdc:fc6955e36b421ec712ba81c97c4c4e93", 
+    "name": "gold:Gp0321285_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321285", 
+    "url": "https://data.microbiomedata.org/503568_186529/img_annotation/Ga0482192_ko.tsv", 
+    "md5_checksum": "8f00996444824379a6954cd0baa130b0", 
+    "file_size_bytes": 55935345, 
+    "id": "nmdc:8f00996444824379a6954cd0baa130b0", 
+    "name": "gold:Gp0321285_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321285", 
+    "url": "https://data.microbiomedata.org/503568_186529/img_annotation/Ga0482192_functional_annotation.gff", 
+    "md5_checksum": "03846205920d3904b3f43807834cb364", 
+    "file_size_bytes": 483162350, 
+    "id": "nmdc:03846205920d3904b3f43807834cb364", 
+    "name": "gold:Gp0321285_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321285", 
+    "url": "https://data.microbiomedata.org/503568_186529/img_annotation/Ga0482192_proteins.faa", 
+    "md5_checksum": "4ce337ca93786854ba56d9869e14f591", 
+    "file_size_bytes": 456909654, 
+    "id": "nmdc:4ce337ca93786854ba56d9869e14f591", 
+    "name": "gold:Gp0321285_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321285", 
+    "url": "https://data.microbiomedata.org/503568_186529/img_annotation/Ga0482192_structural_annotation.gff", 
+    "md5_checksum": "deb40e1f540d8c3d4b50d76104b1a095", 
+    "file_size_bytes": 257369919, 
+    "id": "nmdc:deb40e1f540d8c3d4b50d76104b1a095", 
+    "name": "gold:Gp0321285_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321286", 
+    "url": "https://data.microbiomedata.org/503568_186530/img_annotation/Ga0482191_ec.tsv", 
+    "md5_checksum": "b6366ea7a835691458a6872883636362", 
+    "file_size_bytes": 47862419, 
+    "id": "nmdc:b6366ea7a835691458a6872883636362", 
+    "name": "gold:Gp0321286_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321286", 
+    "url": "https://data.microbiomedata.org/503568_186530/img_annotation/Ga0482191_ko.tsv", 
+    "md5_checksum": "d669d8eae9d8b5949796eb2f4cc393f1", 
+    "file_size_bytes": 70003592, 
+    "id": "nmdc:d669d8eae9d8b5949796eb2f4cc393f1", 
+    "name": "gold:Gp0321286_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321286", 
+    "url": "https://data.microbiomedata.org/503568_186530/img_annotation/Ga0482191_functional_annotation.gff", 
+    "md5_checksum": "f3e17fae5f6e76fa3b1cfa03113dde8f", 
+    "file_size_bytes": 607043335, 
+    "id": "nmdc:f3e17fae5f6e76fa3b1cfa03113dde8f", 
+    "name": "gold:Gp0321286_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321286", 
+    "url": "https://data.microbiomedata.org/503568_186530/img_annotation/Ga0482191_proteins.faa", 
+    "md5_checksum": "1272bd3b3af9bc77f17cc05e368bc7e0", 
+    "file_size_bytes": 594347391, 
+    "id": "nmdc:1272bd3b3af9bc77f17cc05e368bc7e0", 
+    "name": "gold:Gp0321286_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321286", 
+    "url": "https://data.microbiomedata.org/503568_186530/img_annotation/Ga0482191_structural_annotation.gff", 
+    "md5_checksum": "5a4038e9f86c14507cb7a280cf311d84", 
+    "file_size_bytes": 322585055, 
+    "id": "nmdc:5a4038e9f86c14507cb7a280cf311d84", 
+    "name": "gold:Gp0321286_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321287", 
+    "url": "https://data.microbiomedata.org/503568_186531/img_annotation/Ga0482190_ec.tsv", 
+    "md5_checksum": "714f824d90dea21a06e22e5f70473aed", 
+    "file_size_bytes": 58670249, 
+    "id": "nmdc:714f824d90dea21a06e22e5f70473aed", 
+    "name": "gold:Gp0321287_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321287", 
+    "url": "https://data.microbiomedata.org/503568_186531/img_annotation/Ga0482190_ko.tsv", 
+    "md5_checksum": "6caf7a14da0812f5e57cb4697bed9461", 
+    "file_size_bytes": 84832566, 
+    "id": "nmdc:6caf7a14da0812f5e57cb4697bed9461", 
+    "name": "gold:Gp0321287_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321287", 
+    "url": "https://data.microbiomedata.org/503568_186531/img_annotation/Ga0482190_functional_annotation.gff", 
+    "md5_checksum": "1db0880091c36c0977ce45f22dc58464", 
+    "file_size_bytes": 728765342, 
+    "id": "nmdc:1db0880091c36c0977ce45f22dc58464", 
+    "name": "gold:Gp0321287_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321287", 
+    "url": "https://data.microbiomedata.org/503568_186531/img_annotation/Ga0482190_proteins.faa", 
+    "md5_checksum": "f831f58e1761dcde174db82a8054d4a2", 
+    "file_size_bytes": 670229731, 
+    "id": "nmdc:f831f58e1761dcde174db82a8054d4a2", 
+    "name": "gold:Gp0321287_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321287", 
+    "url": "https://data.microbiomedata.org/503568_186531/img_annotation/Ga0482190_structural_annotation.gff", 
+    "md5_checksum": "d058d233fb8da0fa70bf9306d698c2e1", 
+    "file_size_bytes": 390621945, 
+    "id": "nmdc:d058d233fb8da0fa70bf9306d698c2e1", 
+    "name": "gold:Gp0321287_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321288", 
+    "url": "https://data.microbiomedata.org/503568_186532/img_annotation/Ga0482189_ec.tsv", 
+    "md5_checksum": "4a77efe56cb144a8836f95e9e02e5e47", 
+    "file_size_bytes": 40988448, 
+    "id": "nmdc:4a77efe56cb144a8836f95e9e02e5e47", 
+    "name": "gold:Gp0321288_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321288", 
+    "url": "https://data.microbiomedata.org/503568_186532/img_annotation/Ga0482189_ko.tsv", 
+    "md5_checksum": "53ede0b8abd96497214b8d1dc57c5350", 
+    "file_size_bytes": 59910705, 
+    "id": "nmdc:53ede0b8abd96497214b8d1dc57c5350", 
+    "name": "gold:Gp0321288_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321288", 
+    "url": "https://data.microbiomedata.org/503568_186532/img_annotation/Ga0482189_functional_annotation.gff", 
+    "md5_checksum": "5ae3df50b80d100a3af98a695180fcf8", 
+    "file_size_bytes": 514524403, 
+    "id": "nmdc:5ae3df50b80d100a3af98a695180fcf8", 
+    "name": "gold:Gp0321288_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321288", 
+    "url": "https://data.microbiomedata.org/503568_186532/img_annotation/Ga0482189_proteins.faa", 
+    "md5_checksum": "c0e0818e6236ece3756233d62402530b", 
+    "file_size_bytes": 495250030, 
+    "id": "nmdc:c0e0818e6236ece3756233d62402530b", 
+    "name": "gold:Gp0321288_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321288", 
+    "url": "https://data.microbiomedata.org/503568_186532/img_annotation/Ga0482189_structural_annotation.gff", 
+    "md5_checksum": "42abcc0295b474652f5d7e3fd981eaf5", 
+    "file_size_bytes": 272974711, 
+    "id": "nmdc:42abcc0295b474652f5d7e3fd981eaf5", 
+    "name": "gold:Gp0321288_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321289", 
+    "url": "https://data.microbiomedata.org/503568_186533/img_annotation/Ga0482188_ec.tsv", 
+    "md5_checksum": "867066acab1b65ce3f8ec3b2441c7b80", 
+    "file_size_bytes": 73492429, 
+    "id": "nmdc:867066acab1b65ce3f8ec3b2441c7b80", 
+    "name": "gold:Gp0321289_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321289", 
+    "url": "https://data.microbiomedata.org/503568_186533/img_annotation/Ga0482188_ko.tsv", 
+    "md5_checksum": "f3470a6f6205c26c3099cbdd56619dcd", 
+    "file_size_bytes": 107401583, 
+    "id": "nmdc:f3470a6f6205c26c3099cbdd56619dcd", 
+    "name": "gold:Gp0321289_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321289", 
+    "url": "https://data.microbiomedata.org/503568_186533/img_annotation/Ga0482188_functional_annotation.gff", 
+    "md5_checksum": "e5b6e52e7e6da8a3699b8ede666ce1b9", 
+    "file_size_bytes": 939257943, 
+    "id": "nmdc:e5b6e52e7e6da8a3699b8ede666ce1b9", 
+    "name": "gold:Gp0321289_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321289", 
+    "url": "https://data.microbiomedata.org/503568_186533/img_annotation/Ga0482188_proteins.faa", 
+    "md5_checksum": "a1b616853e0d1dcddf8f8c17266a4dab", 
+    "file_size_bytes": 918712621, 
+    "id": "nmdc:a1b616853e0d1dcddf8f8c17266a4dab", 
+    "name": "gold:Gp0321289_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321289", 
+    "url": "https://data.microbiomedata.org/503568_186533/img_annotation/Ga0482188_structural_annotation.gff", 
+    "md5_checksum": "e62a9d17906da4a73dd76b04f974d958", 
+    "file_size_bytes": 501086415, 
+    "id": "nmdc:e62a9d17906da4a73dd76b04f974d958", 
+    "name": "gold:Gp0321289_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321290", 
+    "url": "https://data.microbiomedata.org/503568_186534/img_annotation/Ga0482187_ec.tsv", 
+    "md5_checksum": "847aee43b199ff8396db40d8c4ee3700", 
+    "file_size_bytes": 34618546, 
+    "id": "nmdc:847aee43b199ff8396db40d8c4ee3700", 
+    "name": "gold:Gp0321290_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321290", 
+    "url": "https://data.microbiomedata.org/503568_186534/img_annotation/Ga0482187_ko.tsv", 
+    "md5_checksum": "43ba589665945da68f3006d6bfa74021", 
+    "file_size_bytes": 50015599, 
+    "id": "nmdc:43ba589665945da68f3006d6bfa74021", 
+    "name": "gold:Gp0321290_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321290", 
+    "url": "https://data.microbiomedata.org/503568_186534/img_annotation/Ga0482187_functional_annotation.gff", 
+    "md5_checksum": "0cb130d4376436220b34fa916aa9cfba", 
+    "file_size_bytes": 418909735, 
+    "id": "nmdc:0cb130d4376436220b34fa916aa9cfba", 
+    "name": "gold:Gp0321290_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321290", 
+    "url": "https://data.microbiomedata.org/503568_186534/img_annotation/Ga0482187_proteins.faa", 
+    "md5_checksum": "3617ad6fc98edf20a3b5b9b0bc90b302", 
+    "file_size_bytes": 384596339, 
+    "id": "nmdc:3617ad6fc98edf20a3b5b9b0bc90b302", 
+    "name": "gold:Gp0321290_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321290", 
+    "url": "https://data.microbiomedata.org/503568_186534/img_annotation/Ga0482187_structural_annotation.gff", 
+    "md5_checksum": "848d1a34aad4d6966b3941735cf380b6", 
+    "file_size_bytes": 222631850, 
+    "id": "nmdc:848d1a34aad4d6966b3941735cf380b6", 
+    "name": "gold:Gp0321290_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321291", 
+    "url": "https://data.microbiomedata.org/503568_186535/img_annotation/Ga0482186_ec.tsv", 
+    "md5_checksum": "2d8dd4456b4d3d1d420258ffa9ab8675", 
+    "file_size_bytes": 73916284, 
+    "id": "nmdc:2d8dd4456b4d3d1d420258ffa9ab8675", 
+    "name": "gold:Gp0321291_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321291", 
+    "url": "https://data.microbiomedata.org/503568_186535/img_annotation/Ga0482186_ko.tsv", 
+    "md5_checksum": "65f66e255aaa56c68b15083f3c8ce482", 
+    "file_size_bytes": 107241878, 
+    "id": "nmdc:65f66e255aaa56c68b15083f3c8ce482", 
+    "name": "gold:Gp0321291_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321291", 
+    "url": "https://data.microbiomedata.org/503568_186535/img_annotation/Ga0482186_functional_annotation.gff", 
+    "md5_checksum": "1e698ab3d5a81d4d96de4f820d859817", 
+    "file_size_bytes": 921453004, 
+    "id": "nmdc:1e698ab3d5a81d4d96de4f820d859817", 
+    "name": "gold:Gp0321291_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321291", 
+    "url": "https://data.microbiomedata.org/503568_186535/img_annotation/Ga0482186_proteins.faa", 
+    "md5_checksum": "410f625da0eaebed66a6e8c18b0e53d0", 
+    "file_size_bytes": 874589308, 
+    "id": "nmdc:410f625da0eaebed66a6e8c18b0e53d0", 
+    "name": "gold:Gp0321291_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321291", 
+    "url": "https://data.microbiomedata.org/503568_186535/img_annotation/Ga0482186_structural_annotation.gff", 
+    "md5_checksum": "bf28aaeaf947e64a6fa762f0a2146946", 
+    "file_size_bytes": 492239054, 
+    "id": "nmdc:bf28aaeaf947e64a6fa762f0a2146946", 
+    "name": "gold:Gp0321291_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321292", 
+    "url": "https://data.microbiomedata.org/503568_186536/img_annotation/Ga0482185_ec.tsv", 
+    "md5_checksum": "eb3c2f5a879f052544ffc00f167c3f0a", 
+    "file_size_bytes": 59054821, 
+    "id": "nmdc:eb3c2f5a879f052544ffc00f167c3f0a", 
+    "name": "gold:Gp0321292_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321292", 
+    "url": "https://data.microbiomedata.org/503568_186536/img_annotation/Ga0482185_ko.tsv", 
+    "md5_checksum": "513ebcdefc17d2a0419e0d786d8d9c9b", 
+    "file_size_bytes": 86108056, 
+    "id": "nmdc:513ebcdefc17d2a0419e0d786d8d9c9b", 
+    "name": "gold:Gp0321292_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321292", 
+    "url": "https://data.microbiomedata.org/503568_186536/img_annotation/Ga0482185_functional_annotation.gff", 
+    "md5_checksum": "a301bf732634dc0b2da38821da73bb1d", 
+    "file_size_bytes": 757309747, 
+    "id": "nmdc:a301bf732634dc0b2da38821da73bb1d", 
+    "name": "gold:Gp0321292_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321292", 
+    "url": "https://data.microbiomedata.org/503568_186536/img_annotation/Ga0482185_proteins.faa", 
+    "md5_checksum": "23725b4b671305a23b2f9bea1931dd68", 
+    "file_size_bytes": 754742498, 
+    "id": "nmdc:23725b4b671305a23b2f9bea1931dd68", 
+    "name": "gold:Gp0321292_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321292", 
+    "url": "https://data.microbiomedata.org/503568_186536/img_annotation/Ga0482185_structural_annotation.gff", 
+    "md5_checksum": "b66392e039cbedc07b2674aa1dba6dac", 
+    "file_size_bytes": 402743415, 
+    "id": "nmdc:b66392e039cbedc07b2674aa1dba6dac", 
+    "name": "gold:Gp0321292_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321293", 
+    "url": "https://data.microbiomedata.org/503568_186537/img_annotation/Ga0482184_ec.tsv", 
+    "md5_checksum": "2a021467c5feb3023bac55f1389b7b87", 
+    "file_size_bytes": 42035746, 
+    "id": "nmdc:2a021467c5feb3023bac55f1389b7b87", 
+    "name": "gold:Gp0321293_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321293", 
+    "url": "https://data.microbiomedata.org/503568_186537/img_annotation/Ga0482184_ko.tsv", 
+    "md5_checksum": "ab9099fc7d1a32f23fff9091bafb5b30", 
+    "file_size_bytes": 61332247, 
+    "id": "nmdc:ab9099fc7d1a32f23fff9091bafb5b30", 
+    "name": "gold:Gp0321293_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321293", 
+    "url": "https://data.microbiomedata.org/503568_186537/img_annotation/Ga0482184_functional_annotation.gff", 
+    "md5_checksum": "329bd25a272982d4116287b8b744e4f6", 
+    "file_size_bytes": 512563275, 
+    "id": "nmdc:329bd25a272982d4116287b8b744e4f6", 
+    "name": "gold:Gp0321293_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321293", 
+    "url": "https://data.microbiomedata.org/503568_186537/img_annotation/Ga0482184_proteins.faa", 
+    "md5_checksum": "92eec5b401629df8c01678ce2717c87b", 
+    "file_size_bytes": 477441483, 
+    "id": "nmdc:92eec5b401629df8c01678ce2717c87b", 
+    "name": "gold:Gp0321293_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321293", 
+    "url": "https://data.microbiomedata.org/503568_186537/img_annotation/Ga0482184_structural_annotation.gff", 
+    "md5_checksum": "7eeac4fe7fa630ac5b85e864f3236f2c", 
+    "file_size_bytes": 273412446, 
+    "id": "nmdc:7eeac4fe7fa630ac5b85e864f3236f2c", 
+    "name": "gold:Gp0321293_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321294", 
+    "url": "https://data.microbiomedata.org/503568_186538/img_annotation/Ga0482183_ec.tsv", 
+    "md5_checksum": "1bde731a9e60a62eb99f2a5f2055f675", 
+    "file_size_bytes": 41045081, 
+    "id": "nmdc:1bde731a9e60a62eb99f2a5f2055f675", 
+    "name": "gold:Gp0321294_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321294", 
+    "url": "https://data.microbiomedata.org/503568_186538/img_annotation/Ga0482183_ko.tsv", 
+    "md5_checksum": "ef1d19f662d4301ec3a11cfec9d4b652", 
+    "file_size_bytes": 59431489, 
+    "id": "nmdc:ef1d19f662d4301ec3a11cfec9d4b652", 
+    "name": "gold:Gp0321294_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321294", 
+    "url": "https://data.microbiomedata.org/503568_186538/img_annotation/Ga0482183_functional_annotation.gff", 
+    "md5_checksum": "de0eb7c5f9e4eb24ae8766920fc7a79c", 
+    "file_size_bytes": 511739565, 
+    "id": "nmdc:de0eb7c5f9e4eb24ae8766920fc7a79c", 
+    "name": "gold:Gp0321294_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321294", 
+    "url": "https://data.microbiomedata.org/503568_186538/img_annotation/Ga0482183_proteins.faa", 
+    "md5_checksum": "a77caadf1701b22232ab50ffddce7d26", 
+    "file_size_bytes": 490152930, 
+    "id": "nmdc:a77caadf1701b22232ab50ffddce7d26", 
+    "name": "gold:Gp0321294_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321294", 
+    "url": "https://data.microbiomedata.org/503568_186538/img_annotation/Ga0482183_structural_annotation.gff", 
+    "md5_checksum": "6b79f8e01cfeb858655b267f097ffb9c", 
+    "file_size_bytes": 271872482, 
+    "id": "nmdc:6b79f8e01cfeb858655b267f097ffb9c", 
+    "name": "gold:Gp0321294_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321295", 
+    "url": "https://data.microbiomedata.org/503568_186539/img_annotation/Ga0482182_ec.tsv", 
+    "md5_checksum": "c4187538344a3306f84ab32a28fdf2e2", 
+    "file_size_bytes": 70725001, 
+    "id": "nmdc:c4187538344a3306f84ab32a28fdf2e2", 
+    "name": "gold:Gp0321295_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321295", 
+    "url": "https://data.microbiomedata.org/503568_186539/img_annotation/Ga0482182_ko.tsv", 
+    "md5_checksum": "934b09de148e766213549b5e6c684763", 
+    "file_size_bytes": 102720772, 
+    "id": "nmdc:934b09de148e766213549b5e6c684763", 
+    "name": "gold:Gp0321295_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321295", 
+    "url": "https://data.microbiomedata.org/503568_186539/img_annotation/Ga0482182_functional_annotation.gff", 
+    "md5_checksum": "5efc6f0b3731baf5bb49d7e7ff27e7a6", 
+    "file_size_bytes": 909632945, 
+    "id": "nmdc:5efc6f0b3731baf5bb49d7e7ff27e7a6", 
+    "name": "gold:Gp0321295_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321295", 
+    "url": "https://data.microbiomedata.org/503568_186539/img_annotation/Ga0482182_proteins.faa", 
+    "md5_checksum": "0aabdc855939a32aa78d16892fb74a31", 
+    "file_size_bytes": 893849540, 
+    "id": "nmdc:0aabdc855939a32aa78d16892fb74a31", 
+    "name": "gold:Gp0321295_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321295", 
+    "url": "https://data.microbiomedata.org/503568_186539/img_annotation/Ga0482182_structural_annotation.gff", 
+    "md5_checksum": "8105fb07db3565279cb50332e5fa69e2", 
+    "file_size_bytes": 485904019, 
+    "id": "nmdc:8105fb07db3565279cb50332e5fa69e2", 
+    "name": "gold:Gp0321295_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321296", 
+    "url": "https://data.microbiomedata.org/503568_186540/img_annotation/Ga0482181_ec.tsv", 
+    "md5_checksum": "b0a641550c86ac7d2a957e5af1be77a0", 
+    "file_size_bytes": 39655971, 
+    "id": "nmdc:b0a641550c86ac7d2a957e5af1be77a0", 
+    "name": "gold:Gp0321296_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321296", 
+    "url": "https://data.microbiomedata.org/503568_186540/img_annotation/Ga0482181_ko.tsv", 
+    "md5_checksum": "7e9badf5c89fb1a9c593a14566fe5e3b", 
+    "file_size_bytes": 57510727, 
+    "id": "nmdc:7e9badf5c89fb1a9c593a14566fe5e3b", 
+    "name": "gold:Gp0321296_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321296", 
+    "url": "https://data.microbiomedata.org/503568_186540/img_annotation/Ga0482181_functional_annotation.gff", 
+    "md5_checksum": "97fe89388259cb5c3934bdbdfbe96e0e", 
+    "file_size_bytes": 476861657, 
+    "id": "nmdc:97fe89388259cb5c3934bdbdfbe96e0e", 
+    "name": "gold:Gp0321296_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321296", 
+    "url": "https://data.microbiomedata.org/503568_186540/img_annotation/Ga0482181_proteins.faa", 
+    "md5_checksum": "6e7afaa7acf706291e43b65f87c94030", 
+    "file_size_bytes": 438017040, 
+    "id": "nmdc:6e7afaa7acf706291e43b65f87c94030", 
+    "name": "gold:Gp0321296_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321296", 
+    "url": "https://data.microbiomedata.org/503568_186540/img_annotation/Ga0482181_structural_annotation.gff", 
+    "md5_checksum": "3ffa7a4a98b5106934e304d22cc2bd65", 
+    "file_size_bytes": 253981623, 
+    "id": "nmdc:3ffa7a4a98b5106934e304d22cc2bd65", 
+    "name": "gold:Gp0321296_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321297", 
+    "url": "https://data.microbiomedata.org/503568_186541/img_annotation/Ga0482180_ec.tsv", 
+    "md5_checksum": "0696a840f8ce464eba62eb4341c055a4", 
+    "file_size_bytes": 82919522, 
+    "id": "nmdc:0696a840f8ce464eba62eb4341c055a4", 
+    "name": "gold:Gp0321297_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321297", 
+    "url": "https://data.microbiomedata.org/503568_186541/img_annotation/Ga0482180_ko.tsv", 
+    "md5_checksum": "149e480eb0e2ca5bc6204f665b9a2615", 
+    "file_size_bytes": 120534461, 
+    "id": "nmdc:149e480eb0e2ca5bc6204f665b9a2615", 
+    "name": "gold:Gp0321297_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321297", 
+    "url": "https://data.microbiomedata.org/503568_186541/img_annotation/Ga0482180_functional_annotation.gff", 
+    "md5_checksum": "7eeebc5b1c413d9e8dbc15e4af1a695d", 
+    "file_size_bytes": 1036917219, 
+    "id": "nmdc:7eeebc5b1c413d9e8dbc15e4af1a695d", 
+    "name": "gold:Gp0321297_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321297", 
+    "url": "https://data.microbiomedata.org/503568_186541/img_annotation/Ga0482180_proteins.faa", 
+    "md5_checksum": "41f5b96405652c89c13226494fc3d472", 
+    "file_size_bytes": 996166229, 
+    "id": "nmdc:41f5b96405652c89c13226494fc3d472", 
+    "name": "gold:Gp0321297_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321297", 
+    "url": "https://data.microbiomedata.org/503568_186541/img_annotation/Ga0482180_structural_annotation.gff", 
+    "md5_checksum": "69aedbed08dde951f5b5660697731685", 
+    "file_size_bytes": 553652911, 
+    "id": "nmdc:69aedbed08dde951f5b5660697731685", 
+    "name": "gold:Gp0321297_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321298", 
+    "url": "https://data.microbiomedata.org/503568_186542/img_annotation/Ga0482179_ec.tsv", 
+    "md5_checksum": "35d3ddbc192ecab3a5631db0f76fdf6a", 
+    "file_size_bytes": 39856793, 
+    "id": "nmdc:35d3ddbc192ecab3a5631db0f76fdf6a", 
+    "name": "gold:Gp0321298_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321298", 
+    "url": "https://data.microbiomedata.org/503568_186542/img_annotation/Ga0482179_ko.tsv", 
+    "md5_checksum": "61c6b1164b53526fb0f00f4c24392330", 
+    "file_size_bytes": 57733636, 
+    "id": "nmdc:61c6b1164b53526fb0f00f4c24392330", 
+    "name": "gold:Gp0321298_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321298", 
+    "url": "https://data.microbiomedata.org/503568_186542/img_annotation/Ga0482179_functional_annotation.gff", 
+    "md5_checksum": "84f74f304578f7e593e08e4121839bc2", 
+    "file_size_bytes": 494455830, 
+    "id": "nmdc:84f74f304578f7e593e08e4121839bc2", 
+    "name": "gold:Gp0321298_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321298", 
+    "url": "https://data.microbiomedata.org/503568_186542/img_annotation/Ga0482179_proteins.faa", 
+    "md5_checksum": "cef441d37e63c1221a31e8fad178df3e", 
+    "file_size_bytes": 466333444, 
+    "id": "nmdc:cef441d37e63c1221a31e8fad178df3e", 
+    "name": "gold:Gp0321298_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321298", 
+    "url": "https://data.microbiomedata.org/503568_186542/img_annotation/Ga0482179_structural_annotation.gff", 
+    "md5_checksum": "cae5e9077fc171a1e33329bab7526ddc", 
+    "file_size_bytes": 262774123, 
+    "id": "nmdc:cae5e9077fc171a1e33329bab7526ddc", 
+    "name": "gold:Gp0321298_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321299", 
+    "url": "https://data.microbiomedata.org/503568_186543/img_annotation/Ga0482178_ec.tsv", 
+    "md5_checksum": "4731d121169b2695666f6356610718cd", 
+    "file_size_bytes": 114433835, 
+    "id": "nmdc:4731d121169b2695666f6356610718cd", 
+    "name": "gold:Gp0321299_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321299", 
+    "url": "https://data.microbiomedata.org/503568_186543/img_annotation/Ga0482178_ko.tsv", 
+    "md5_checksum": "901c07c73907fbf0e48b41f8dd51d6e0", 
+    "file_size_bytes": 166904099, 
+    "id": "nmdc:901c07c73907fbf0e48b41f8dd51d6e0", 
+    "name": "gold:Gp0321299_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321299", 
+    "url": "https://data.microbiomedata.org/503568_186543/img_annotation/Ga0482178_functional_annotation.gff", 
+    "md5_checksum": "3d7b91fa19ddd4b6ffbb395716fa0298", 
+    "file_size_bytes": 1482803708, 
+    "id": "nmdc:3d7b91fa19ddd4b6ffbb395716fa0298", 
+    "name": "gold:Gp0321299_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321299", 
+    "url": "https://data.microbiomedata.org/503568_186543/img_annotation/Ga0482178_proteins.faa", 
+    "md5_checksum": "fdd916457ddcf1bf5daf58de328918c7", 
+    "file_size_bytes": 1458486550, 
+    "id": "nmdc:fdd916457ddcf1bf5daf58de328918c7", 
+    "name": "gold:Gp0321299_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321299", 
+    "url": "https://data.microbiomedata.org/503568_186543/img_annotation/Ga0482178_structural_annotation.gff", 
+    "md5_checksum": "54cc460952c8094aaace3e475ad49170", 
+    "file_size_bytes": 794903967, 
+    "id": "nmdc:54cc460952c8094aaace3e475ad49170", 
+    "name": "gold:Gp0321299_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321300", 
+    "url": "https://data.microbiomedata.org/503568_186544/img_annotation/Ga0482177_ec.tsv", 
+    "md5_checksum": "6dd3f862aff867342b1a7c84e5c69adf", 
+    "file_size_bytes": 37555843, 
+    "id": "nmdc:6dd3f862aff867342b1a7c84e5c69adf", 
+    "name": "gold:Gp0321300_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321300", 
+    "url": "https://data.microbiomedata.org/503568_186544/img_annotation/Ga0482177_ko.tsv", 
+    "md5_checksum": "43bfe528d2535d158e14fa5644304173", 
+    "file_size_bytes": 54519956, 
+    "id": "nmdc:43bfe528d2535d158e14fa5644304173", 
+    "name": "gold:Gp0321300_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321300", 
+    "url": "https://data.microbiomedata.org/503568_186544/img_annotation/Ga0482177_functional_annotation.gff", 
+    "md5_checksum": "fe964169df2eccb05f25491090748cc5", 
+    "file_size_bytes": 468593383, 
+    "id": "nmdc:fe964169df2eccb05f25491090748cc5", 
+    "name": "gold:Gp0321300_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321300", 
+    "url": "https://data.microbiomedata.org/503568_186544/img_annotation/Ga0482177_proteins.faa", 
+    "md5_checksum": "60c0ee336af5cc2039c3f7273e00975a", 
+    "file_size_bytes": 451697438, 
+    "id": "nmdc:60c0ee336af5cc2039c3f7273e00975a", 
+    "name": "gold:Gp0321300_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321300", 
+    "url": "https://data.microbiomedata.org/503568_186544/img_annotation/Ga0482177_structural_annotation.gff", 
+    "md5_checksum": "ed394322e9312dba63b271c7484797a9", 
+    "file_size_bytes": 248283267, 
+    "id": "nmdc:ed394322e9312dba63b271c7484797a9", 
+    "name": "gold:Gp0321300_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321301", 
+    "url": "https://data.microbiomedata.org/503568_186545/img_annotation/Ga0482176_ec.tsv", 
+    "md5_checksum": "23f685792e01b19b7d4c7c9a592e3fc9", 
+    "file_size_bytes": 52717667, 
+    "id": "nmdc:23f685792e01b19b7d4c7c9a592e3fc9", 
+    "name": "gold:Gp0321301_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321301", 
+    "url": "https://data.microbiomedata.org/503568_186545/img_annotation/Ga0482176_ko.tsv", 
+    "md5_checksum": "088296d001a191fdba4af60837e4918b", 
+    "file_size_bytes": 76166529, 
+    "id": "nmdc:088296d001a191fdba4af60837e4918b", 
+    "name": "gold:Gp0321301_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321301", 
+    "url": "https://data.microbiomedata.org/503568_186545/img_annotation/Ga0482176_functional_annotation.gff", 
+    "md5_checksum": "fd1989f8cf71ca897641a46524242bd0", 
+    "file_size_bytes": 639071961, 
+    "id": "nmdc:fd1989f8cf71ca897641a46524242bd0", 
+    "name": "gold:Gp0321301_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321301", 
+    "url": "https://data.microbiomedata.org/503568_186545/img_annotation/Ga0482176_proteins.faa", 
+    "md5_checksum": "fecf564c2c3f7150ad596624178c8c10", 
+    "file_size_bytes": 587024045, 
+    "id": "nmdc:fecf564c2c3f7150ad596624178c8c10", 
+    "name": "gold:Gp0321301_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321301", 
+    "url": "https://data.microbiomedata.org/503568_186545/img_annotation/Ga0482176_structural_annotation.gff", 
+    "md5_checksum": "9cfd08fa7dac9d59c866d32fbcd79e8f", 
+    "file_size_bytes": 341637740, 
+    "id": "nmdc:9cfd08fa7dac9d59c866d32fbcd79e8f", 
+    "name": "gold:Gp0321301_Structural annotation GFF file"
+  }, 
+  {
+    "description": "EC TSV File for gold:Gp0321302", 
+    "url": "https://data.microbiomedata.org/503568_186546/img_annotation/Ga0482175_ec.tsv", 
+    "md5_checksum": "033adebfc63b7f5cd1a0a590c8018281", 
+    "file_size_bytes": 45042293, 
+    "id": "nmdc:033adebfc63b7f5cd1a0a590c8018281", 
+    "name": "gold:Gp0321302_EC TSV File"
+  }, 
+  {
+    "description": "KO TSV File for gold:Gp0321302", 
+    "url": "https://data.microbiomedata.org/503568_186546/img_annotation/Ga0482175_ko.tsv", 
+    "md5_checksum": "6388680dcab4a88c07f21c91777b782d", 
+    "file_size_bytes": 64627247, 
+    "id": "nmdc:6388680dcab4a88c07f21c91777b782d", 
+    "name": "gold:Gp0321302_KO TSV File"
+  }, 
+  {
+    "description": "Functional annotation GFF file for gold:Gp0321302", 
+    "url": "https://data.microbiomedata.org/503568_186546/img_annotation/Ga0482175_functional_annotation.gff", 
+    "md5_checksum": "5307f9b714e36dee8bf55e3e197ec9b9", 
+    "file_size_bytes": 523453585, 
+    "id": "nmdc:5307f9b714e36dee8bf55e3e197ec9b9", 
+    "name": "gold:Gp0321302_Functional annotation GFF file"
+  }, 
+  {
+    "description": "Protein FAA for gold:Gp0321302", 
+    "url": "https://data.microbiomedata.org/503568_186546/img_annotation/Ga0482175_proteins.faa", 
+    "md5_checksum": "934ee6e733522628856c63b94e5527a3", 
+    "file_size_bytes": 497254586, 
+    "id": "nmdc:934ee6e733522628856c63b94e5527a3", 
+    "name": "gold:Gp0321302_Protein FAA"
+  }, 
+  {
+    "description": "Structural annotation GFF file for gold:Gp0321302", 
+    "url": "https://data.microbiomedata.org/503568_186546/img_annotation/Ga0482175_structural_annotation.gff", 
+    "md5_checksum": "9a583be5f87563056c19eb94042bf19d", 
+    "file_size_bytes": 276409351, 
+    "id": "nmdc:9a583be5f87563056c19eb94042bf19d", 
+    "name": "gold:Gp0321302_Structural annotation GFF file"
+  }
+]
+}

--- a/examples/img_mg_annotation_objects.json
+++ b/examples/img_mg_annotation_objects.json
@@ -1,0 +1,2284 @@
+{"activity_set":
+[
+  {
+    "has_input": [
+      "nmdc:b4b798cc9e7e9253ae8256a8237fd371"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0153825", 
+    "has_output": [
+      "nmdc:a1f2c190aa6d470f2eea681126e0470e", 
+      "nmdc:7d69d28f4abec72a7ad66411312c37fb", 
+      "nmdc:c3ea4b3caf0c86e27118b3ffd51014b8", 
+      "nmdc:a79973ef9a0c96d13fa19b2725b21d17", 
+      "nmdc:1055b8fab0f63a1e56312813f47897ec"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0153825", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9076b6e2b334532d7be4e48b25ca80dd", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:70fba0e579271c70e65c7ef5909958ed"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119849", 
+    "has_output": [
+      "nmdc:b7abebe872fb705d2cdd5fcd36becf0e", 
+      "nmdc:5b2e3bf2abc084710300eb4668638ed3", 
+      "nmdc:f574e3392aa40d786a566ae4bc0a5932", 
+      "nmdc:c09c5f5c4f776e6250cf35003e939729", 
+      "nmdc:fd3023efdffe55105bc192f5b6cb4675"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119849", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:bf16723c3a2b226747c6b40085f51cc2", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:04b7e946dd85306cc75eb3c59f26bf1d"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119850", 
+    "has_output": [
+      "nmdc:dd84dbd2e1b611a1cb6f855f578538d3", 
+      "nmdc:72bc285bcb9a4e0bff1b99719cf8346b", 
+      "nmdc:e18017e4d7721b9aa8f6fe0604d61d28", 
+      "nmdc:c93e3ebaf3c21c50bb1071d0e07daa48", 
+      "nmdc:6e16b6f3d73dc771eba4c729600c9551"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119850", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:c77fe920a664d4e174d413ec89f040a3", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:76a9fb6a1d29da495d246728ab7ace33"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119851", 
+    "has_output": [
+      "nmdc:bdfa927dbe2d5bbf27f1a1cf0265a27f", 
+      "nmdc:0ab4c3c5fb624a9931ac977df5a4aa4f", 
+      "nmdc:4b6e2700378acc2a9ac22195a9b4cbfb", 
+      "nmdc:f8219a779a150e71c672dd2bfd695365", 
+      "nmdc:adfd5d1e9ec99ea5917d8b9efdbd9130"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119851", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:6c5858d2b28e1de316120d410ed62544", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:9f3d6c465517c7bca53391ab998dad82"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119852", 
+    "has_output": [
+      "nmdc:de071cd0e3010778b9f491e846b95179", 
+      "nmdc:793aa923c27dd8cc762625f96ff52f80", 
+      "nmdc:678d467ad6c4ad6d7ba2f259585c4acd", 
+      "nmdc:18c7f9fe5340509f00326c70c1815e88", 
+      "nmdc:4b43a24ab20530a72e06a8721b2c09db"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119852", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:879e7ff3374deee6054684076a882649", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:50175f6f32192a797c58d2ef636efa37"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119853", 
+    "has_output": [
+      "nmdc:2bd72614bf1a394de064eb6148074d22", 
+      "nmdc:af374a8de732aa3c85eba74b5d29fb66", 
+      "nmdc:db7baf32a8a49b586b8ff70b67487863", 
+      "nmdc:c0c580b59189351b4f4919701e4db0f2", 
+      "nmdc:14e390786d1f1eb60835aca96081ab23"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119853", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:608cc16c1e395be8f7f56f123b88d17a", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:772095f1e8e7033ff8f5e5a42308347c"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119854", 
+    "has_output": [
+      "nmdc:93e586051957e0f4a451b70ceeac04ab", 
+      "nmdc:6b974729dc47b7795b17fac36d496cfa", 
+      "nmdc:3361194f90da2d18830213cd4587aa71", 
+      "nmdc:dba970c890226f16b008f8043ca38d9b", 
+      "nmdc:b476e6c11fed4a3254eda4d15a4183c7"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119854", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:db089a3971603b130cc25c9edf29a951", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:fb5ab52924b554184ac31308e4126b44"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119855", 
+    "has_output": [
+      "nmdc:465d9547f4c5d5aa4d341555f5769d9a", 
+      "nmdc:34a4bbe14e8867d45e95e205738b6d3f", 
+      "nmdc:7a953d15a0f368c71cb365c2dd888a83", 
+      "nmdc:bb8a58ce8c8850f95dc84aa49a7a96f7", 
+      "nmdc:3a05f63e1899f82d11d931adfe69d86a"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119855", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:1762bbeb64674af6e394ee1323391833", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:9d774aebab719174e5b3113c65fe5860"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119856", 
+    "has_output": [
+      "nmdc:e1c28a3028e3fb994d48c67c3cad4ab4", 
+      "nmdc:41b3a8590d7ad384f5a92bfd74267f5f", 
+      "nmdc:5726d2d4081cd3a257e15e98f5a45f8c", 
+      "nmdc:42164be43a9ab6da393c7d48825e289e", 
+      "nmdc:72aaf6784de9aa35be58e12898bff353"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119856", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:4794bbc1dc72807df92a30088cf4551b", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:33fa88501b23f0498c6af05c5924704e"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119857", 
+    "has_output": [
+      "nmdc:ecbfb703f2b4204f9f67de20840bd355", 
+      "nmdc:60524c5c69a1c8b4a2609f4a9cb3a490", 
+      "nmdc:4a4032318b50bdc3bae5d290a7f0735e", 
+      "nmdc:5a77bb24847fcbf1c3fec6c40aa2ac14", 
+      "nmdc:89ef0619642dead830035ac9389ca802"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119857", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9cb27d7fe967ed437acf43b7cb5f01ee", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:f5e854c22a065f2895f99a0119b1b41a"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119858", 
+    "has_output": [
+      "nmdc:db4fc71545bef12273f70878ad83a7fe", 
+      "nmdc:503667333d0a31fa41da4885bea45c8c", 
+      "nmdc:8e0746f6759e85ee867f85191d83a1e9", 
+      "nmdc:0b7a5694aefdea2070dd1b21a21a9abb", 
+      "nmdc:43157d8de38b673ce4a4d70ee3a1198c"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119858", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:b52fd6e2d28c922c305849b2e6e29246", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:b6adc0392be1b4d327e57c7630de47f5"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119859", 
+    "has_output": [
+      "nmdc:ed4bc44713888809173573d96114f11e", 
+      "nmdc:18cdf12e824a7fb6255dbcac79a2a9a0", 
+      "nmdc:1729d54d35a1445759d4a85cbd4e305c", 
+      "nmdc:eb09f7f461ad13a47bf5609cdcfc853c", 
+      "nmdc:10128acfa04b42839c133fe298eab941"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119859", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:f23f9cd69666b01795e4c43bacb9ae62", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:fdc028609bab950eb4289953fbe03aa5"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119860", 
+    "has_output": [
+      "nmdc:cf2282967219cfc4462f91840aae4126", 
+      "nmdc:7137d225d4e84d63175b89e1f74b7728", 
+      "nmdc:2fa5357b6e025470478224cc8c4d8443", 
+      "nmdc:613152955d79f4344828738fb898d679", 
+      "nmdc:959ef4ff2d105052b094138aa09b5c94"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119860", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9278b29bb5c234046a11937991a3a652", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:0cb2e3b5ce7e14d6bb08eec2a31d247a"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119861", 
+    "has_output": [
+      "nmdc:066d13964ce47a41a1e2ef7a5b19cb59", 
+      "nmdc:218b0daa573a8a7f5fc31d6cfe1edad5", 
+      "nmdc:4f13ca8028e6581e0510d8667456bf28", 
+      "nmdc:1712f2bb1fa749515ce0bf2b34f8b559", 
+      "nmdc:0f06cb228b08e2aee24c65444d0bfc21"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119861", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:67d82e4c6f9796611f5a2234596eb6a2", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:1b4116c5fa8023a05811814bde3d66f0"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119862", 
+    "has_output": [
+      "nmdc:ceb802e43562a90b5dc028d818a8f56d", 
+      "nmdc:9ebfce5805ecaeb07521c28690fa810c", 
+      "nmdc:895b148dc332f979f35fae25156762d8", 
+      "nmdc:19e4e0238ac9c1d07646431ee62fa2d9", 
+      "nmdc:d8e967e38a491678164ab203551aad61"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119862", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9e9c8643f496b6472ddb602aff30021d", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:8565741217a0632488535b5b20afa036"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119863", 
+    "has_output": [
+      "nmdc:091275dd5ad1358b576671f22c2f8157", 
+      "nmdc:2318ee29172751d9f66edc54c7a456fa", 
+      "nmdc:f5a9c910bcb6cbec92291db526caa1db", 
+      "nmdc:8be139ccce758a8845092122546ff2b3", 
+      "nmdc:46cf62901adcbcb2ca2c890b6dc8e6bd"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119863", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:facd1cd7880760c4d227237d8142d60b", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:279ac03ea9aa6cce7c1e23119643b70e"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119864", 
+    "has_output": [
+      "nmdc:cc49ea1669ce6a40e73b17880ebdf36e", 
+      "nmdc:30dc605e7458353cd12e0700042f8b23", 
+      "nmdc:7ae6e443b360f01d0655aa6066e06c87", 
+      "nmdc:b803f40f00f0c9988dd5968acd4821cb", 
+      "nmdc:3695d84852c6345c02f5f1c3e3f3a423"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119864", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:6c6eff8448b4782e31363eb7a783ef16", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:cbb78531961f6eab3b0f8ef2fa488801"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119865", 
+    "has_output": [
+      "nmdc:e34ef5954fd12e5fdab0bae08414b001", 
+      "nmdc:a58d0ad82bcd82747443a05133e86d4a", 
+      "nmdc:1f5ea69be09b6f086c09af241d6b9df5", 
+      "nmdc:73e37fa7c4626d47580d5705cb656383", 
+      "nmdc:9f23cbec97a89ce503564d05b061f37f"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119865", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:3d2d6fbece4298a34798a5cdc28fccbc", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:3d0615c9034cfba43866390d717f8de8"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119866", 
+    "has_output": [
+      "nmdc:9101306c31f4b8c544f1671e66607a87", 
+      "nmdc:4ef712b7b38e384c25a31fc24c39aab9", 
+      "nmdc:e4f33c52b87b07d9f50cda6bf067d710", 
+      "nmdc:2de8312087081f9aeac56c56195a5fc2", 
+      "nmdc:5d1bb402cf5170de632179f2515a224f"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119866", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:993f0fb1fb43a8db2c04f6a6064d1e91", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:203d4e9e3d7999df5978a77217526d42"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119867", 
+    "has_output": [
+      "nmdc:e1b8a1bb51b7c8421ed748d3da31cab9", 
+      "nmdc:e5a23d1c8e78d044bb907acb7490c223", 
+      "nmdc:a4403a73bfd1f57ce219127cd1ebed51", 
+      "nmdc:b20ef196169b86e1498e45194adeff8b", 
+      "nmdc:fd11757a61a2400b5ed8077c62cc97b9"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119867", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:8a43ec3baf8aafe09d96eb7fbf58c916", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:e30d13f5b218da7692120ac3351f9569"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119868", 
+    "has_output": [
+      "nmdc:0289e4fda11b48fb48c641c8e309b3ed", 
+      "nmdc:df46e32e073a15273bb1f709b15abcd3", 
+      "nmdc:ff55ba482b074f7f3d56c64da1b3c9c8", 
+      "nmdc:3c788da6e9004cd3ec276d5e44b19548", 
+      "nmdc:804bc97cd8e16289290024ea3a7edbde"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119868", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:57e9c4e31f9c612633325bbe5c6c2f87", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:7ab8f7dcc03e512ef3ab2143b63cc8de"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119869", 
+    "has_output": [
+      "nmdc:aa524a698ead96378589ebfec51375f4", 
+      "nmdc:475a785b8c7e1de1e88d36b2863ad1d8", 
+      "nmdc:ec5a78019044659ab89e4703a2ab57ff", 
+      "nmdc:c46f4c6ee971aff627dcbfc8f1e3a9e8", 
+      "nmdc:431354e60f7a35b67c2f7ec52b955808"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119869", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:60c965c51b96153a9cffa6f4dd62a2e6", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:68fb8b64adf5c219f787dc8bb5d94480"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119870", 
+    "has_output": [
+      "nmdc:9b89126b81c06ae693353614f72344cb", 
+      "nmdc:ba17d066f634e0bcc16fbcc7f1ff55f0", 
+      "nmdc:56c01b4ba33b765ad4a478d662a11e75", 
+      "nmdc:977d1fc2445d1aecd5f30e0197535af9", 
+      "nmdc:4b204c8e49c59d862209579b79c44545"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119870", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:42addbcd527a65d01a4d2fbd2da7758a", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:b35b812f128516b0d12910c71df77b1c"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0119871", 
+    "has_output": [
+      "nmdc:0c72d3d72c8f29761c48d2844cbbd858", 
+      "nmdc:cf3c06ff9bb95e6e76b26bdd29add799", 
+      "nmdc:c2b7fc5a3e992bb271559774a779c890", 
+      "nmdc:8c6e1665a12e9478f7f13b9177b08083", 
+      "nmdc:b2f6e385af8cbe49df3044d523da5c82"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0119871", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:3204b453fe3471a5c6babce54398d9af", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:9339ba4d7b731220024b995f87ddc5e1"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127623", 
+    "has_output": [
+      "nmdc:d6afa54f891852b3a5befc294ce84489", 
+      "nmdc:e15c4db1e4e26208b302ecb9bc2c094c", 
+      "nmdc:3acc269b9e2b5e97ffcc3c1a0d85381c", 
+      "nmdc:be62e3b68916c8077955d0b3d3aaf5aa", 
+      "nmdc:feb21db71dc44afceeb88bb725315b42"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127623", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:92070449b2ee66f6ec04125edc8ae30a", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:70c6cfaac2821e95aad6732da590276e"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127624", 
+    "has_output": [
+      "nmdc:73ebb84a8744552c890ad2508e313972", 
+      "nmdc:89a4bb36ef225146a2ba0daaaea512fd", 
+      "nmdc:6bcdfc58ee6b4eb5ae022c71636a88b4", 
+      "nmdc:075262a23b12fd4da073a973a5b6cf15", 
+      "nmdc:3fb3966095303ea8aa7f27bff3e9db50"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127624", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:f0773e35f29db6c8c9ec2354b6560c5f", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:593237bf7f38f66d40eca1dbb23c7aef"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127625", 
+    "has_output": [
+      "nmdc:16eb9d7ffc8dbf8872cbdb9b7f0a1c82", 
+      "nmdc:18dd16caf7af261c4d647da91a6f526a", 
+      "nmdc:3b039b9d5a75b97a67edf5d50b34d9f0", 
+      "nmdc:c6fb34fc2da63a5cc46522279e768db9", 
+      "nmdc:bf23db2dda841d77cf51b7c9120ba503"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127625", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:dfbc92d67d6307fc16059f858f8d81f6", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:59e99f35194f3f98fa07d401dddd4959"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127626", 
+    "has_output": [
+      "nmdc:dde9a2b70a0552a8d6f7cda7f4862aa9", 
+      "nmdc:1f45d481e2882a15e7d060e47cbbfda3", 
+      "nmdc:8e19f17a8fd0747410b68d804b87139d", 
+      "nmdc:11741b35b589852f2b652d1f73afb663", 
+      "nmdc:f1b6a4b001b67ec72eb5b5411e1321c9"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127626", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:b17f7734657148a50baf5216849b3b2f", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:245e4bf7ae2d630d26223054f851e31c"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127627", 
+    "has_output": [
+      "nmdc:4c97ec34649fc995f167408bd39c9998", 
+      "nmdc:874ae45fc2a007a7d5f9ff964fa8117a", 
+      "nmdc:6c96999ab72498624aae8bb9b0bfbc66", 
+      "nmdc:fec0b3842897bbce9166a628c4c2d7a0", 
+      "nmdc:48ab9737528d088ffde37b733e3f728f"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127627", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:4b54a8416db39168fa6403d6832476e6", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:e54d5475a6bf7148d2312d0fcc349cdb"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127628", 
+    "has_output": [
+      "nmdc:760a1e1bc5aac21dd0b96098c72133ff", 
+      "nmdc:69da278e8966a688cafb7bb2c8f2e4d1", 
+      "nmdc:b73bf45facd909d89bfab76dee85a2cc", 
+      "nmdc:ec55b61e1204cde7fe61841179b88b53", 
+      "nmdc:bd55dfd59ed0aa7ea685734c5b7ecbab"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127628", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:689781c3f0a680b05f9a0a9b377b0ed9", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:9eed2da9f67c58f243329daf2289f40e"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127629", 
+    "has_output": [
+      "nmdc:f9211f36dc6992c2dfecd160987434c7", 
+      "nmdc:37fb326b25c1ae3caebddf668feadd76", 
+      "nmdc:75e43708767f06de878e1c2115714e0b", 
+      "nmdc:9559ebd9a8921ff8ae9f89c2ffcef6f7", 
+      "nmdc:9b3fb3e409e3d3128a8a43cc58d32a95"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127629", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:d8af769e0dd753e86ef1f545536f3024", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:c3958f0be344c850d06ee61865c95ff6"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127630", 
+    "has_output": [
+      "nmdc:81ab86211731bc0547d3e8f8786c3e8b", 
+      "nmdc:c6b5f388349af0214d65d1357026c7ee", 
+      "nmdc:070f0952308650d35ae05c4fed188677", 
+      "nmdc:6bca5ad106b3519416205a82d3a14b16", 
+      "nmdc:f921989651475b06052058126db54de9"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127630", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:b579670a8b80fd02e453d5ac031a574e", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:ff68d07b09e5a9cdd866208394d66bd6"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127631", 
+    "has_output": [
+      "nmdc:ee276fe3eb490475ad3d7280a8c67464", 
+      "nmdc:e2ef79ef2b6669d93af5e90ba2c58fcf", 
+      "nmdc:5723e7023b0e3994e92c7c5e72aa34ec", 
+      "nmdc:04c97ac7af06bf37da8f1ffe827e454d", 
+      "nmdc:d57f28027b2d6f82b96f5413bf8c9a59"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127631", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:406be722709ec331037987b30acc6b18", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:8f8931e086f72961675aa936b1356f86"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127632", 
+    "has_output": [
+      "nmdc:b8d886e71031cbe4fb1284f479348740", 
+      "nmdc:aeafeb18adb193b1a3c5c3c2ff9a912e", 
+      "nmdc:2395040203b3351554a9e3ffb48b0b88", 
+      "nmdc:a89e8af0fc6daf895e7a87f1ff7087f2", 
+      "nmdc:89b895fbf3c13801ddba22ff59bb385a"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127632", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:163dfd2463186259deeae10b15d25119", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:e04c866a9a015bec110f1235db7223dc"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127633", 
+    "has_output": [
+      "nmdc:31e2f5b7b055f2959d50a990ebda7ff6", 
+      "nmdc:9ef3a52b2d97cc4afb64e37d04e59865", 
+      "nmdc:740240c975daffee3e63251fc86cfd33", 
+      "nmdc:79fd564d59bf9fe4cfb2c771daa84f29", 
+      "nmdc:b18381667b4e7401e1bb58e8aede5d4a"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127633", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:ac967b73a027cfac522a742ddbbf9521", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:b502e282cb52690232ce6ec6e1cfd4bc"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127634", 
+    "has_output": [
+      "nmdc:01b078b5b9dde5699e9b9ab02af272df", 
+      "nmdc:5b2ff10d97d2b516716a67dafb137937", 
+      "nmdc:803451414e1935d4de9f9911963efe8d", 
+      "nmdc:3374b8708ae6b77b16cd01ce4f33ee72", 
+      "nmdc:1e286398d6b164538bbdefb9cc8a41e9"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127634", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:8287ea44a458b50606a04fe82ceb83b1", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:178298f959546299f78fb2bff07cd460"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127635", 
+    "has_output": [
+      "nmdc:9e0a73962f7014df93613b04fae9f8be", 
+      "nmdc:4cddc89fb8b405210d66b836825c37ee", 
+      "nmdc:4768d5de701a1ac55ed0c2d57a270dd2", 
+      "nmdc:b2ee2639269e6d665f772fc8c4e31d07", 
+      "nmdc:e1cd02b3a92223d8e30e8d7c90837d9a"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127635", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:e763e255fa74e2629d7d86e10f838d4b", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:555541de209f6b5bc8b4e36f9c5a96c1"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127636", 
+    "has_output": [
+      "nmdc:80ec7d76d2509e6eeab61d092808908b", 
+      "nmdc:d68e6d4245c33a73666148570aac9c10", 
+      "nmdc:31f8346eeca4b929a6c28686bb8b2043", 
+      "nmdc:66d9d6751efad0b8019a565488f950a5", 
+      "nmdc:e3b57dff7ca37c0da6b7d4bfb4450d9c"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127636", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:89dde14d6545e93e749ffeae6fc3bdd6", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:d66bd2d4b3ad1abef6787addfb5aa8b6"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127637", 
+    "has_output": [
+      "nmdc:1549562abe1044734fab8562585ec161", 
+      "nmdc:ce74f349e03ae28dd49fc5ea4cd1d91d", 
+      "nmdc:74b2fc3dd196a3d615c7d0d478fa2f90", 
+      "nmdc:c43a6b5a306a8f14aab780d8f1bf9c41", 
+      "nmdc:5f6b287493cde8cf8cb49348a2868aa6"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127637", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:507c53e61a3c02d763b05d2a5eb2bda5", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:ed782cb1e889b9965707363c1324ee22"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127638", 
+    "has_output": [
+      "nmdc:3bd360103e4e8fc8f89c1df345367776", 
+      "nmdc:1aba5135d8cddc36da3cd37579be190b", 
+      "nmdc:3da4d2f1c2db68033fa2264f4db7f459", 
+      "nmdc:17993d4fcfa7be4fd4488804d23b67c6", 
+      "nmdc:2ca3e1a0ba8007e86dedbec47e85adba"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127638", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:93656c96853f97524040c44f4b346d75", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:1d1610f39b4543fe7a0ecde2b1d8d710"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127639", 
+    "has_output": [
+      "nmdc:7e710e983d3a5ffbddc618c5e252e06b", 
+      "nmdc:ccbc768cb20e4c1b25d7627b611eb8dc", 
+      "nmdc:ee416a49155f7c07bcb776962708fb04", 
+      "nmdc:fccc8283a46f12babeed0b2c7cc4eebd", 
+      "nmdc:d0452fefd4ad4f4cd10c974294bf9058"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127639", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:78ec466d9918b7fa1cbc033b19a37a10", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:e2d5ce50f49731a49740d9f61f630550"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127640", 
+    "has_output": [
+      "nmdc:e90b16891cff9bd5b0034cc6c89f8080", 
+      "nmdc:4950dc66d2b5a3c325454fb106d6b726", 
+      "nmdc:86b6734c5eb64c0cae6e95fa7f062123", 
+      "nmdc:1fbb7302a6ad581085d561e9fd3ed802", 
+      "nmdc:812cf8b77747ff65cfd237158535d310"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127640", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:5ac74427da62d00b8493cf6bc7c8e43d", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:a707d24e95ee536650d1cc70bbf997d8"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127641", 
+    "has_output": [
+      "nmdc:71306193abf043865cafa413b3ca9c1e", 
+      "nmdc:4ec0cbf7d166057c3d2904b2dd2f6b15", 
+      "nmdc:11d4524c896f4fd678ff05a0547b6b52", 
+      "nmdc:d10b0c9b0d5e646d09c570eb2e08b793", 
+      "nmdc:a33ac2dc640b7088767a99517f22421f"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127641", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:6808e9a6d7450f02019691d89c57ff1f", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:1e4e73c9d1faa4585cb3a266b5a6cd39"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127642", 
+    "has_output": [
+      "nmdc:4f8de602126deeb9ef60cf5f739d601a", 
+      "nmdc:65319d4c3ffdbf5dcdb2e2837aea8cf4", 
+      "nmdc:657b2348517d3e169df0914f5d8a2d21", 
+      "nmdc:263acdd17bdb9ed72102610070da3d65", 
+      "nmdc:9e55f66e86f57487e23029b90a84c4a4"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127642", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:45f4a9d66e8d45a534fc2067670bf012", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:e087926bf099d6b56eaa8ed38dc9587c"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127643", 
+    "has_output": [
+      "nmdc:0b7fc1ad662f267eaa604075f9968b7c", 
+      "nmdc:b7b422e726f82668cd9c2ea9f0786f41", 
+      "nmdc:f8df0729f51da70739b75a2458e32020", 
+      "nmdc:7434bd60874fc6d05530ee0652a9e18f", 
+      "nmdc:d897fea88896a93843966962f6bbb7be"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127643", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:b59602d74d9ee08ccd285a7ac2e5f6b2", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:f40e4315c5285ac27f850a924b9f0d19"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127644", 
+    "has_output": [
+      "nmdc:03c32c8ae757623520f6211ff641c40a", 
+      "nmdc:3eced892c4712a2b13e805a978ec0819", 
+      "nmdc:0626957517790befa95e8fefad58be0c", 
+      "nmdc:2c7d55cbee1f35793da90275740d3651", 
+      "nmdc:0973e6d47848f6677ced2a8d463670fa"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127644", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:339e8f1e41b780e4e565ce53067bc9bb", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:eb1d97165017b3e14d15f6407a181be3"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127645", 
+    "has_output": [
+      "nmdc:17524561a0e1f2c9d9ffdebc3b2df6a8", 
+      "nmdc:e2b3ea50301aa3efaea18732ddba04f4", 
+      "nmdc:c3a8cfa76e5da83b2b24bc6a52f71952", 
+      "nmdc:2ab0820d09b9c331ec56d7d3e20552e6", 
+      "nmdc:06280b3737fbf704d850ac68da190166"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127645", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:e148a2d4befa290bbd216b6654371606", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:cfb56be5f505927c085fb3105561b578"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127646", 
+    "has_output": [
+      "nmdc:9d87100ad8b6278b4a442c4686d7aef7", 
+      "nmdc:5cd2f970cbb8eb5d8e52ac7a08bfb9a3", 
+      "nmdc:c0858f9a847f241ed28f454adb580bf4", 
+      "nmdc:646648c11733f7ab7ea23008729360ce", 
+      "nmdc:94574634e1ccfe241af033259e27df1a"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127646", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:02aca43c6efc414d5971e8a179bbbcf0", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:9aefb925f949c698cd2a0d71d1d2d7cc"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127647", 
+    "has_output": [
+      "nmdc:18d40bd5ff2707ba9a4512363d05537d", 
+      "nmdc:d855bc2d72a6ba238acfe746299cf26a", 
+      "nmdc:af2496c3ae96ff31e6bdaae75b507ea7", 
+      "nmdc:ec6d01297279eee2d4c03ecfda9309c9", 
+      "nmdc:a57c9b7f192351676e897b8187cf6641"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127647", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:4488991684ed07f2b9a2bb5b8b1a59a9", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:621134d8dd8a6b117924f92ffed69ba7"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127648", 
+    "has_output": [
+      "nmdc:06042b9d083bd6b9879bc5486c0b38ba", 
+      "nmdc:1287c2532770a0f0d6792192c7400c0c", 
+      "nmdc:c11e44f28b422233e151d324d2accb43", 
+      "nmdc:d27fabc532b52dec4afa4673f920633a", 
+      "nmdc:863f93ecf208a6e19f17d460d8e1a963"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127648", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:ca2cac5f3de8db080031d727ff4db8ec", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:6300cd8140abe6322e4a9c1921584476"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127649", 
+    "has_output": [
+      "nmdc:a14b836f963c0f6b02a70f0fc8cd40c0", 
+      "nmdc:35c0fd91c2225f595df469b61ba9578b", 
+      "nmdc:a022fd9c3254ad5dc6ae5be40cd35c0b", 
+      "nmdc:56c3ac34fb2f1c2ba7bcd9bd56be731a", 
+      "nmdc:cff0a71781a84c7096ee79b39c3336f8"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127649", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:1524a48694d670c26a1b55238d9f1949", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:49c49b255b8db84f4b79e0ad5a963c82"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127651", 
+    "has_output": [
+      "nmdc:2a7c5ba82dff4dd5d996ad5bc824103c", 
+      "nmdc:84dc1abc2d39254da6c3d2cd6cff6d9d", 
+      "nmdc:e25cb289f398c007806c72c080724872", 
+      "nmdc:67dfacdfc27cb6b0ec4787e1a40d9547", 
+      "nmdc:714fb73a8b3011d0b2faea98eda477c3"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127651", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:e96dba76c7c388aebab7ad759b2a5694", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:e8bc7228a422a7c1a2641276ee3f6e37"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127652", 
+    "has_output": [
+      "nmdc:06ceb99673dcb924ca223539267a962a", 
+      "nmdc:4d16f813aefc09c7720770f065964c49", 
+      "nmdc:80c28fa3efc78e6d23d0abcf1161c983", 
+      "nmdc:48bb698de57cd77bf1ddda9004e89c01", 
+      "nmdc:6b39045cb99ca6220e27c4fa960f4dd1"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127652", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:5e21f299a395e845341500a334e94ff2", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:c9708409d9e8f45dcc89e688b3482e5e"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127653", 
+    "has_output": [
+      "nmdc:05cc9ce5321d6bc909ab63b8cbc59d02", 
+      "nmdc:44f8e708349a1effdff745880f4fdd12", 
+      "nmdc:8d83e502a533b5db8cd3bc943ae8b18b", 
+      "nmdc:658231efecf9d087ec2a6e9467f4e968", 
+      "nmdc:511ae319ddff2bdcbc3296d951e42d7e"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127653", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:d6f99d25d421ab54908e603b016df20f", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:cd12b50afea3097034758d6883864dd5"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127654", 
+    "has_output": [
+      "nmdc:b785c7809fa99d5beca859eded4a9b0f", 
+      "nmdc:3b7734343770dce929591ee83d96acb6", 
+      "nmdc:b28a675c6560b34691a960f7e873841d", 
+      "nmdc:deda4116aac7e262c0edf3358bb8e384", 
+      "nmdc:a9cf54b925e1c5b8c3e0299730f5a464"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127654", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:405d59d65f666d1bb1f44393bf6b3c1a", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:2860c363baa5fd6e5bbdc96a8d54b56b"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127655", 
+    "has_output": [
+      "nmdc:32c6c6dbce4a1c6ab92810a86f90c574", 
+      "nmdc:6d1185f4034e364b74109d40326a450a", 
+      "nmdc:0b4a5dc91c42b7fea3fd514d5cb3138b", 
+      "nmdc:a31096eb3e473fd0c68d09096bc3fd85", 
+      "nmdc:05e2702ecae6ba0ba0b0898132850b9f"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127655", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:82124fe8afc73ce5f61011ba9520ae38", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:3dfd278d5e4fc3539b6dfd021acdac76"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0127656", 
+    "has_output": [
+      "nmdc:33e0f5ff7c448ded210f04798894a031", 
+      "nmdc:8d230dd7948d2b08c4de1adc0d0002b8", 
+      "nmdc:00f42710ff9df37cd23e5e73d54e4dd1", 
+      "nmdc:2819bbb349ca5bdbf311aeae6ada532b", 
+      "nmdc:0c2ae5a86d4840a0b324d73977170f1e"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0127656", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9bdf633bcd7d5b9bb1bf95ccd26349cd", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:b78f599c21fb31b00d3f8a3c56daeb88"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115664", 
+    "has_output": [
+      "nmdc:8a812604db9b4e2bdbad6d0b3539f6ea", 
+      "nmdc:76537a4ab5012ba3b407471da373ef1c", 
+      "nmdc:bc034c7024043ea88b44d0897bb5bece", 
+      "nmdc:fc419491cce16671e828d76083252841", 
+      "nmdc:10117f9500d0dd54655a5d70195f7df5"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115664", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:686818cb31dc45d3d4482847ec007584", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:333b8256818eefecf0581f31a45719f9"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115675", 
+    "has_output": [
+      "nmdc:b30bdfcd025588bd80ebb3bcdad2cdc8", 
+      "nmdc:7ab72f45de20843e167ee1e595bb752d", 
+      "nmdc:e745ff0c0a95c89393f8789cd8c409e9", 
+      "nmdc:51f3c008db6a106ee14e160f35f7d9f3", 
+      "nmdc:dcb8211231f718d57e22f8dea1efc6d0"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115675", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:2e10913bdcfacfeeab4d9f7a0aa2af8f", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:b2f2d476b77fca0725cb68b0305ea3b0"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115673", 
+    "has_output": [
+      "nmdc:da4d331daa6d5965be8e201c3c9ba4d4", 
+      "nmdc:73cac6bcbfa2627ab291bf230ded9748", 
+      "nmdc:b7264d7a1c56fc32c4a0c050fe04208e", 
+      "nmdc:d325906b9b82b3bfc2fe8ed7321a828e", 
+      "nmdc:2fba563f11988f4e30d2b4283c3c5487"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115673", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:b3bd170070e9c37f535de92c9f37b2b4", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:9ca27b985234aaed07e3f6659e0416d0"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115677", 
+    "has_output": [
+      "nmdc:8a39e09943350e563b00e23a146c3ec1", 
+      "nmdc:34d53203f08e6c25c8f85f6e04d6df24", 
+      "nmdc:e7df895e1a7776ba16b6d77fdc9b077d", 
+      "nmdc:c0365d39cb481d6e0f729b587dac10c8", 
+      "nmdc:bfbd1bd1ad70307dd01b699ecc4ffb2a"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115677", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:fdd5f518cea894505f0bd6ac02205ba3", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:d1dee40a000226d9f2c8f4f05e0f85f1"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115678", 
+    "has_output": [
+      "nmdc:240064338b65f944556e88ebd44fbd03", 
+      "nmdc:cfe4a8ce52735eedacc38bacdc8785e4", 
+      "nmdc:6d1553b3e100a61f3b2b453fb7e71094", 
+      "nmdc:78a99f435ce2bdd6cd83ebb807dc0ef3", 
+      "nmdc:ac989404b8a9e07880788cfb061015ba"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115678", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:42613f7c1fa860e847e2c93e2462b6f7", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:2235febcd5329a40beb86d8d8411e0c1"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115665", 
+    "has_output": [
+      "nmdc:b4a623a8d9418c04567b5712889fcdfd", 
+      "nmdc:e28746f79f2d58d71fd5f42dff8b6dd5", 
+      "nmdc:dceabe03f9758a72038b9824794337e1", 
+      "nmdc:1b5b79d300bb60afffec76da4cda7f14", 
+      "nmdc:431860b46c896880c1d8d779fb2645ec"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115665", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9b6144e11b277a1f020c54da4ee79bac", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:cbbbd9da9ae7fc0d7cd3ad507977a0fe"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115671", 
+    "has_output": [
+      "nmdc:75e88ab163c9d092836f9110768c6a52", 
+      "nmdc:9c6c644e821021661d936d374ee9fc1b", 
+      "nmdc:8f5a7f2db6790e67282439becd4c04b2", 
+      "nmdc:f5a4336c7ac10e908cfe90a61a991c65", 
+      "nmdc:ad6e88d469fbad7b0684afb933403a6c"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115671", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:c65521ed98ca6f569686debc46ea274d", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:aa60f90793266081a0ba6d125fb06e55"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115666", 
+    "has_output": [
+      "nmdc:4e3f389524497182aa3e8832aa7b373b", 
+      "nmdc:ab262feeaf856be190b60ea7c0a4c030", 
+      "nmdc:a1e8795537eca0522357d60045780ab3", 
+      "nmdc:70c8e0fc6e64b20e99a4c0f783014142", 
+      "nmdc:654201c4699079bdd923dcff52881c07"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115666", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:638923494b08b936cefdac95ef58c558", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:17cff5e222ad522c357863eb39418117"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115669", 
+    "has_output": [
+      "nmdc:e74cb5e168717574193a15d5ac04a01f", 
+      "nmdc:0bc9b55e2d8f3c45b18725845815bfde", 
+      "nmdc:4f7a6e682f6f13b7ea73511265fdd2a9", 
+      "nmdc:6de20d427454895dce6caeb7b9543c11", 
+      "nmdc:9c68523f458ee1f8ec395e1442b1f508"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115669", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:73840751bf8835b680aff13d0eb2335a", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:28a8512eff8b81cebce0614fe5ed18a0"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115667", 
+    "has_output": [
+      "nmdc:babc9f95621eed35bc7975dee8b417b9", 
+      "nmdc:bc5043b689463c3651c15ad4ba1aa9a4", 
+      "nmdc:c47020ef7958f3a4c4458e0797fc2400", 
+      "nmdc:acdedd1c48e28e4f4e0d0679cae417f9", 
+      "nmdc:6f236cc8b728333fcf85e4f27873a500"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115667", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:7b684248db11762d14a95ebdda7e8a81", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:6525bd7de120f6ed4dd75069d597f261"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115676", 
+    "has_output": [
+      "nmdc:bc4755bf8b2c0b7c384eb4ffd8e9e017", 
+      "nmdc:23762ea8dc5ce375c3827aded41ae2c0", 
+      "nmdc:d429e7a9bb0344196ed7bcca6131e3c0", 
+      "nmdc:5193d8fa7e151b96396afa8d61851af8", 
+      "nmdc:e3b04bb85be48814ca078ee871a9296b"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115676", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:87eb3326bcc84557dc334eff00d4a0bf", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:0ce94528dc5ad4d5b62293d4d95c1e9e"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115668", 
+    "has_output": [
+      "nmdc:bcbae14f9733da2b512b5f5b6c8fcb98", 
+      "nmdc:dbd78725415f5f8e80f590c3588a1c60", 
+      "nmdc:c57d28f7dd791aab5c4caee00b247ef9", 
+      "nmdc:f97c44951275f8b68fa94ded40fda756", 
+      "nmdc:b4764f173896dcb134d7c94c1ee13ca3"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115668", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:87de8edb421c5364ee75c172715292cc", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:0a3d00715d01ad7b8f3aee59b674dfe9"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115663", 
+    "has_output": [
+      "nmdc:27319f58c616a07159e1fac12635bd4b", 
+      "nmdc:8d250650c90956edff8bafccc56fd630", 
+      "nmdc:b7e9c8d0bffdd13ace6f862a61fa87d2", 
+      "nmdc:754074d3bcade65aba2a6f8236619ab7", 
+      "nmdc:a4b4c623457aa10161d88a9ac4eef522"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115663", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:2d9a6d5e57ab455c257d8c3424331113", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:6c7beb91bbdcda84076fd786d59cab20"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115670", 
+    "has_output": [
+      "nmdc:483453952f8e4dc70687e02842b2bfc8", 
+      "nmdc:4226d30b4f7d4018245613abbb2cc254", 
+      "nmdc:75a1e23a29f8b793c0b0abb7778d8661", 
+      "nmdc:7e531f55eba2bd29d5bb4b1af8417b7c", 
+      "nmdc:f05ecf0db08d716edb7a3f499582a2b7"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115670", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9994a8414976fd6b56935648246493b5", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:f74d007a0d55515291e2ab3ecd50461f"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115672", 
+    "has_output": [
+      "nmdc:e029f10a29dd5e9d81dce82c2211fdee", 
+      "nmdc:f6230d3d3eadab80074ecfe59a623c10", 
+      "nmdc:5c1afd4ffb1b1594807fbd0901da7a88", 
+      "nmdc:b0687d58e2803a41864c9d830977402b", 
+      "nmdc:644d67586f9337bf4d12ff5859d4cd54"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115672", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:932040eace29833c2b528f4279446285", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:1689f2f2e14c55ab5d2af78ad3eb99bd"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115674", 
+    "has_output": [
+      "nmdc:72ede7603b72206d929c03364769021c", 
+      "nmdc:9c248ab2a22c7b49060e544f37b9c798", 
+      "nmdc:876382e7107a83b87a059e4e961bff75", 
+      "nmdc:c70d6973abeb3ee231d3e38c3c5dced4", 
+      "nmdc:17f2fbdeb3f5891c37f2e9e43a40c7b1"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115674", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:5981c6f73f7cdc963866091b0101a9b7", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:4fb2f3e8ebd99cea1e797e248b2e5c1d"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0115679", 
+    "has_output": [
+      "nmdc:aa5fa1b83592459bd3e742be4949d0b1", 
+      "nmdc:ee75eaed19b9a259e0e70e20a53f7fba", 
+      "nmdc:b8c895face8e8e77bbfc7163c7eb7850", 
+      "nmdc:21f3d777493f87403b60a4a1b3dd2f1b", 
+      "nmdc:b63b42c7892b4a14e5661bca5bfa2419"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0115679", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9fcee63f77040c2b8cc0726b15f9f068", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:40addaf8b9d84a5d076dbd654eb840a1"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321263", 
+    "has_output": [
+      "nmdc:0c9d8d131453a814cc825668d7c18987", 
+      "nmdc:cd0dca213375e3c8b0266932dfff5bb6", 
+      "nmdc:a487ead0b28de8ac44169345638c140c", 
+      "nmdc:1d25e5266e86688b9e65764a9f181e27", 
+      "nmdc:3725668a447e1c7e7e639376a1017e8f"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321263", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:8d355d3c7070686b0beb20e39d17e172", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:b7ff9345cd91d675846caf34f557f4f7"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321264", 
+    "has_output": [
+      "nmdc:3bbaf98e3147e0e0ef35aa56f99775b6", 
+      "nmdc:035b62005530d9f9927da7ac7b9d4407", 
+      "nmdc:a76306b513c2c244bf2899284eed67c4", 
+      "nmdc:409f86c6fccbe946bc56108427b01108", 
+      "nmdc:e4e0da015bbaafeb9199ad669ae71702"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321264", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9269f143d88b7d5ff3c61897cfef80a7", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:778bdc544d09cf85360c78a1dd2e263c"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321265", 
+    "has_output": [
+      "nmdc:175f44d76765b2555c0e94e5f05fd3a1", 
+      "nmdc:63a567ada447f75cfc2c7fd2d45f8a39", 
+      "nmdc:f4aaf8a82d86aa0273b984ffb1c52dd6", 
+      "nmdc:1de4cc65fa1e329eccf2cc9982b126aa", 
+      "nmdc:b91dc0c20caa465338c63c01e2c1328c"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321265", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:36f15e6f9d8426dbc49ea6928b6b4bb6", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:a1c12622adf52a2fd9f0fa79302a03e1"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321266", 
+    "has_output": [
+      "nmdc:0448dc8c7da28b362275a213adfaeaf6", 
+      "nmdc:8314866bf8dc46a8934cf8b193e21b2e", 
+      "nmdc:422fda8c954e7ffc99883d561fb6f75b", 
+      "nmdc:a98cf4ad6cc56d5a1992c1c5b8027525", 
+      "nmdc:e19fcc4f4eeb2ebaa6deec9f53e1e2d7"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321266", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:c6acdfbb7449a3faf079ec67396af96b", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:5660c815bdf2b740f4d1942e8cdb5611"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321267", 
+    "has_output": [
+      "nmdc:8c46e28d633eb9243f9edd0368a66f44", 
+      "nmdc:9cb8fdc5cd7bd605f3fcff2ea39cfbf5", 
+      "nmdc:e2708c2679b2002486bb6c4cc1fcc1f1", 
+      "nmdc:716d26a135a99c9efc8c49d4b294f8e8", 
+      "nmdc:ff9b33e360b07cf16501e4002cceb1a3"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321267", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:739891753f88a2359b78191f41c19ad0", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:59b28e87d2e4c7c9c796cfc1d5ac93ac"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321268", 
+    "has_output": [
+      "nmdc:c530c02506fb7f4c0e90eaa46ef931f9", 
+      "nmdc:9047db5ed7d535f7a8cf238feea4112e", 
+      "nmdc:d8e3a237e08fe7b14816ed38cb15f7e5", 
+      "nmdc:313edf6edf574cd30a06f3695c98c0fe", 
+      "nmdc:8ebacf3cb9208f5788c4a664e2bb6155"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321268", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:428a67c345a48187f0924d3af673c83c", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:2b0b0ceb40543eab2045a790f18ede00"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321269", 
+    "has_output": [
+      "nmdc:d110ababa05ffea4c73fd7f6c2823a01", 
+      "nmdc:0edba9c3bac0163e9ee8d3acc138f0be", 
+      "nmdc:920ffe0caa9796066c6dc232ca29e4bf", 
+      "nmdc:8036d9e860e7c6ac63d62389b012cc39", 
+      "nmdc:1eebc50c86e6e560d910b68358c76117"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321269", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:3f1eb315892bb62126887cce05bdae32", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:c3131aef261fe1ff6a16d30705a40ba8"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321270", 
+    "has_output": [
+      "nmdc:513baf8db74eaf64d7aa7698f1cf31b7", 
+      "nmdc:e9a333448ef41a27086e8df2b1ba6476", 
+      "nmdc:488174c4683c9fe45eae35664a4f7774", 
+      "nmdc:f76b4199f7c1a19bbec3f8a3c39967c8", 
+      "nmdc:d325fdb48d28bb5e04b261496c897a80"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321270", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:63648550d5280b9de5c61fc3d9f75f27", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:c293b6b51556d2c536a4f59488498829"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321271", 
+    "has_output": [
+      "nmdc:55982ed44eeba03a461a3b837f8344d8", 
+      "nmdc:ede2997cb8cb2cdd14d9aa415157ecdd", 
+      "nmdc:1e90bfe885aac91db1abd71c03ff283c", 
+      "nmdc:1492b148b7432379040c78f4b1d84eed", 
+      "nmdc:d5241932493adac238e254fe0ea0b1b3"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321271", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9593e1500765d71b2a9eeb87ff22cb7a", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:009f426c6f632a1c4c437695ab32ffc9"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321272", 
+    "has_output": [
+      "nmdc:18bc1ef31ea841c4eb135a4598d4643e", 
+      "nmdc:e20aeed82d3c566fcc454be8dcb30a48", 
+      "nmdc:f5dc696f69438dcbaa2c5c1685db322e", 
+      "nmdc:311a2b8d368d7f20869eb709f6a2fbca", 
+      "nmdc:456ee70f5d3428e1a1326bf3b3a3f45b"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321272", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:8e3f1f49fdd583134060849f51c4c9b2", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:e8b2fd75ef4ade7cb2ddcf7518b9441c"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321273", 
+    "has_output": [
+      "nmdc:bfa6d313b084b76f378fe23e58693729", 
+      "nmdc:cd1b72215cb87dcc9f582a4b42ba39e2", 
+      "nmdc:edd6a05489d203f580a0c8b4db6f239b", 
+      "nmdc:fd5fd05a55dad39734cb7845be8f1455", 
+      "nmdc:f6c682e41266abf2a82301cee11ecc2c"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321273", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:10c34e648ade3d60e9a82c234293c3ad", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:1fa65ac6726132609611b14a32375702"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321274", 
+    "has_output": [
+      "nmdc:75c5338fc5735f215fbff0c0a7ea89f7", 
+      "nmdc:451db12e17920c73990ed6019cffb75e", 
+      "nmdc:7c860f38be54584abbf65b05d023ab9b", 
+      "nmdc:880903dfa10de6c316ea4b5648c65022", 
+      "nmdc:28399ee3579aabdd7a96181a85a36b08"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321274", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9fb743bed2cae43e0c86553b046e1ec3", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:cdcfea8549196bff3b249f57b2b10214"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321275", 
+    "has_output": [
+      "nmdc:b134b99e3681cb2f6882d70e0505a295", 
+      "nmdc:a94304d7af292aefec5fbeb0bcbb7685", 
+      "nmdc:4d8a2a87ea74daac3495c512fd96d96c", 
+      "nmdc:ad8da930414a7a388eb050a8b6fc089f", 
+      "nmdc:6f23809a438fa0ab8784393345dd9485"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321275", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:43eaacb2ce2ac16f5ac67ccecfcd66be", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:48e1a9d8fbb26b86ca7690ea86fdd226"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321276", 
+    "has_output": [
+      "nmdc:1195d877af5d70a04d1af414939fe76a", 
+      "nmdc:afa84ad89ba252703ca11305b2b45915", 
+      "nmdc:98f986365776814d44158c1ef6cfd5e0", 
+      "nmdc:cbfb3e7e74bb881dcb516e1d0388a9f7", 
+      "nmdc:6c84c9ba98e6d4420568ccdee2d8f0ba"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321276", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:b4656c5f9122aab8e12e40bc24bec749", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:95ac596eeef164fae7a2810d2719070f"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321277", 
+    "has_output": [
+      "nmdc:e78cc5ab16e013800bd4cca3a76ca314", 
+      "nmdc:a654d80633b26c66d4c6dd30988e3083", 
+      "nmdc:7a00101741bd9366a36d6e2a60cf0345", 
+      "nmdc:835275caf77ddcc493b4354cb4d10eab", 
+      "nmdc:7222ad2fb0e606000ea88c4d22595c1b"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321277", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:aa45b2e1b2a903ffe1861ff6c2afcb51", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:dad86bb85b336bcdb636b084b8e73774"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321278", 
+    "has_output": [
+      "nmdc:a964f01c89dd3b6575fd1214fe021c3e", 
+      "nmdc:aff1f1e47e91e8df247fed3a28a6998e", 
+      "nmdc:f620e02d2c26b5f2c0db7d77f2168e66", 
+      "nmdc:2cd8a777b2b2f56a47e8f99269c2278e", 
+      "nmdc:36c79ccbf21d3d76d92e670e24ca0321"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321278", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:7f6f6431a81d831ade7a2c66ec675f3a", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:df768c9feb5f43f1c5f1d86f0b3056f8"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321279", 
+    "has_output": [
+      "nmdc:e93e03eb9d260a9ff4d58f10f8ce033d", 
+      "nmdc:8756ede859a2eeb165294bc60757161a", 
+      "nmdc:32ca08ad6221ce0282f7e560d84b6bc1", 
+      "nmdc:1150c8570758aea8c9b32602ac9df694", 
+      "nmdc:3be5100c3d71a32afbe19ba3bd9648d2"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321279", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:642b62309801412cc0020f1b9e02f2bf", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:567601493de0856012f9ea4e6fef9107"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321280", 
+    "has_output": [
+      "nmdc:287108afe4b88d94e576549e1053fd72", 
+      "nmdc:1f5cd6b40da64aad6847e6b393764ba9", 
+      "nmdc:4541de98c3049d59ca8aed9b5dce9096", 
+      "nmdc:ca620fc038f51501e1dd5af9bf085231", 
+      "nmdc:20def41369f21c85f890c13663dc7c38"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321280", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:b51eda7aa71887b5c3d87a88ae9ef886", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:205be20f2bdbe32f19cac507c398d62a"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321281", 
+    "has_output": [
+      "nmdc:aaacc4e710bee5cd3dcf0373126df7df", 
+      "nmdc:7fb1738c852a309fba1fbc2d608da042", 
+      "nmdc:37e76dc62740e3e9cde6fd0ac56fd149", 
+      "nmdc:27eb4ee0689bfa1ed5de639be9dfe4a4", 
+      "nmdc:5adfd50423654d4ee2a7ea1cb047903b"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321281", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:24cc70779dc20ddcb8472360e94c1adb", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:868d58953f9ec7fcdfeae0ed168fa8fa"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321282", 
+    "has_output": [
+      "nmdc:59a2715743627c1746e93b3c4737c7a1", 
+      "nmdc:18957818ea8c9b81ca7cc6b051109f98", 
+      "nmdc:2fe451504079842f4aed6fc3fc4234f0", 
+      "nmdc:b4785d3de1e96579a0139fd62b46c2b1", 
+      "nmdc:64eb490c848063b2d2ec3a67e25e9fc0"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321282", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:3c9a77593015e132a0fcb47e32077c78", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:fde97881f9654b875616b4d73fb5d6fd"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321283", 
+    "has_output": [
+      "nmdc:3a1dcb36da8d2a8e0bd75839eb87ea92", 
+      "nmdc:b609fcbf134b41436694f56d0206e33d", 
+      "nmdc:50bc1b45ffe95d3def7b0acc0652082f", 
+      "nmdc:371a4bc8b331c5a58f5eae72aa7f2ef2", 
+      "nmdc:dae48dbf003f88ae694fa4461cce315d"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321283", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:86ebdd0ce08264d2642a571956d686db", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:436c60e246576c9ea7eef80eb60d03e4"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321284", 
+    "has_output": [
+      "nmdc:3760f2f322ccb7bd25bd9e73529e4bc0", 
+      "nmdc:46f93869937443dd0c5c75e22877cb49", 
+      "nmdc:0f5d384d0a5394fec7546cd4a16dc5cb", 
+      "nmdc:73c7f3cc99686ec1e603fa63596b904f", 
+      "nmdc:79216bdd4f78c73571a7eba424e10b4c"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321284", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:8c0f927607c2b240824a5c52800d4c04", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:b8b7349fd2e0c665bbbdd87ca0226726"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321285", 
+    "has_output": [
+      "nmdc:fc6955e36b421ec712ba81c97c4c4e93", 
+      "nmdc:8f00996444824379a6954cd0baa130b0", 
+      "nmdc:03846205920d3904b3f43807834cb364", 
+      "nmdc:4ce337ca93786854ba56d9869e14f591", 
+      "nmdc:deb40e1f540d8c3d4b50d76104b1a095"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321285", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:030d8c58a26cc8164ce629b8e988532a", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:159f0ce3b00a313f8388e13a7835be4b"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321286", 
+    "has_output": [
+      "nmdc:b6366ea7a835691458a6872883636362", 
+      "nmdc:d669d8eae9d8b5949796eb2f4cc393f1", 
+      "nmdc:f3e17fae5f6e76fa3b1cfa03113dde8f", 
+      "nmdc:1272bd3b3af9bc77f17cc05e368bc7e0", 
+      "nmdc:5a4038e9f86c14507cb7a280cf311d84"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321286", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:132d4df2f27d60ae8fb093248975462f", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:e444c151de53be9abd34e58acf2be075"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321287", 
+    "has_output": [
+      "nmdc:714f824d90dea21a06e22e5f70473aed", 
+      "nmdc:6caf7a14da0812f5e57cb4697bed9461", 
+      "nmdc:1db0880091c36c0977ce45f22dc58464", 
+      "nmdc:f831f58e1761dcde174db82a8054d4a2", 
+      "nmdc:d058d233fb8da0fa70bf9306d698c2e1"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321287", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:6dfbdbcd7ab18ee7b2d213124e239cf6", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:9f51c9468e7faed170bf77a03dc30b07"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321288", 
+    "has_output": [
+      "nmdc:4a77efe56cb144a8836f95e9e02e5e47", 
+      "nmdc:53ede0b8abd96497214b8d1dc57c5350", 
+      "nmdc:5ae3df50b80d100a3af98a695180fcf8", 
+      "nmdc:c0e0818e6236ece3756233d62402530b", 
+      "nmdc:42abcc0295b474652f5d7e3fd981eaf5"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321288", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:1f8036641fc942724894de3ed94df671", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:c9fca6c9a98430936aade8145d6bee7a"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321289", 
+    "has_output": [
+      "nmdc:867066acab1b65ce3f8ec3b2441c7b80", 
+      "nmdc:f3470a6f6205c26c3099cbdd56619dcd", 
+      "nmdc:e5b6e52e7e6da8a3699b8ede666ce1b9", 
+      "nmdc:a1b616853e0d1dcddf8f8c17266a4dab", 
+      "nmdc:e62a9d17906da4a73dd76b04f974d958"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321289", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:9b38ed417fe51b52f3afbe0ac56b25c1", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:53310b5b3d553d212ef78c943eef848b"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321290", 
+    "has_output": [
+      "nmdc:847aee43b199ff8396db40d8c4ee3700", 
+      "nmdc:43ba589665945da68f3006d6bfa74021", 
+      "nmdc:0cb130d4376436220b34fa916aa9cfba", 
+      "nmdc:3617ad6fc98edf20a3b5b9b0bc90b302", 
+      "nmdc:848d1a34aad4d6966b3941735cf380b6"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321290", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:4e839407423180f709d7d5a81e6f070f", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:22a876d17b12588c2a668ce1c26212b9"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321291", 
+    "has_output": [
+      "nmdc:2d8dd4456b4d3d1d420258ffa9ab8675", 
+      "nmdc:65f66e255aaa56c68b15083f3c8ce482", 
+      "nmdc:1e698ab3d5a81d4d96de4f820d859817", 
+      "nmdc:410f625da0eaebed66a6e8c18b0e53d0", 
+      "nmdc:bf28aaeaf947e64a6fa762f0a2146946"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321291", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:65a4e2c6d56914ab2e923aedd3441c4d", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:d7a5f3ca0ce01d380d166d231175d19e"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321292", 
+    "has_output": [
+      "nmdc:eb3c2f5a879f052544ffc00f167c3f0a", 
+      "nmdc:513ebcdefc17d2a0419e0d786d8d9c9b", 
+      "nmdc:a301bf732634dc0b2da38821da73bb1d", 
+      "nmdc:23725b4b671305a23b2f9bea1931dd68", 
+      "nmdc:b66392e039cbedc07b2674aa1dba6dac"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321292", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:5e2e998dfbfbfde7091237749c8d9028", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:ec774f4a8a52a34daa68ab345856cfd6"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321293", 
+    "has_output": [
+      "nmdc:2a021467c5feb3023bac55f1389b7b87", 
+      "nmdc:ab9099fc7d1a32f23fff9091bafb5b30", 
+      "nmdc:329bd25a272982d4116287b8b744e4f6", 
+      "nmdc:92eec5b401629df8c01678ce2717c87b", 
+      "nmdc:7eeac4fe7fa630ac5b85e864f3236f2c"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321293", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:1d1f5b339f19cc457782e86e04688b9f", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:3aeced2c6f61639135e21faab643646f"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321294", 
+    "has_output": [
+      "nmdc:1bde731a9e60a62eb99f2a5f2055f675", 
+      "nmdc:ef1d19f662d4301ec3a11cfec9d4b652", 
+      "nmdc:de0eb7c5f9e4eb24ae8766920fc7a79c", 
+      "nmdc:a77caadf1701b22232ab50ffddce7d26", 
+      "nmdc:6b79f8e01cfeb858655b267f097ffb9c"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321294", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:fd71f805d1e05eae9f38d7d16de66299", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:baae9294f2e086c4f4d54522c68a3547"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321295", 
+    "has_output": [
+      "nmdc:c4187538344a3306f84ab32a28fdf2e2", 
+      "nmdc:934b09de148e766213549b5e6c684763", 
+      "nmdc:5efc6f0b3731baf5bb49d7e7ff27e7a6", 
+      "nmdc:0aabdc855939a32aa78d16892fb74a31", 
+      "nmdc:8105fb07db3565279cb50332e5fa69e2"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321295", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:7fbff9ac4fe3633f9f762069ed572b1c", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:dcd51279c075c4511406e36450ca6787"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321296", 
+    "has_output": [
+      "nmdc:b0a641550c86ac7d2a957e5af1be77a0", 
+      "nmdc:7e9badf5c89fb1a9c593a14566fe5e3b", 
+      "nmdc:97fe89388259cb5c3934bdbdfbe96e0e", 
+      "nmdc:6e7afaa7acf706291e43b65f87c94030", 
+      "nmdc:3ffa7a4a98b5106934e304d22cc2bd65"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321296", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:327db9baa82cc3d9de443613cea1ee35", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:080bfdc30a14a0ebe427055b82609a59"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321297", 
+    "has_output": [
+      "nmdc:0696a840f8ce464eba62eb4341c055a4", 
+      "nmdc:149e480eb0e2ca5bc6204f665b9a2615", 
+      "nmdc:7eeebc5b1c413d9e8dbc15e4af1a695d", 
+      "nmdc:41f5b96405652c89c13226494fc3d472", 
+      "nmdc:69aedbed08dde951f5b5660697731685"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321297", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:6b8a96eb366ae631aa86badd9d11e9ae", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:c017cf104bfd57c9cb2723ff6ce41304"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321298", 
+    "has_output": [
+      "nmdc:35d3ddbc192ecab3a5631db0f76fdf6a", 
+      "nmdc:61c6b1164b53526fb0f00f4c24392330", 
+      "nmdc:84f74f304578f7e593e08e4121839bc2", 
+      "nmdc:cef441d37e63c1221a31e8fad178df3e", 
+      "nmdc:cae5e9077fc171a1e33329bab7526ddc"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321298", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:17fadd9c29b2374dbee61bd95e3f0a02", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:daeccf51c3e846abcd03a4faa65fd237"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321299", 
+    "has_output": [
+      "nmdc:4731d121169b2695666f6356610718cd", 
+      "nmdc:901c07c73907fbf0e48b41f8dd51d6e0", 
+      "nmdc:3d7b91fa19ddd4b6ffbb395716fa0298", 
+      "nmdc:fdd916457ddcf1bf5daf58de328918c7", 
+      "nmdc:54cc460952c8094aaace3e475ad49170"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321299", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:8456c04883daa652cd3c8ef61440c602", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:59e0d4534fe87c754c5818022b38f03e"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321300", 
+    "has_output": [
+      "nmdc:6dd3f862aff867342b1a7c84e5c69adf", 
+      "nmdc:43bfe528d2535d158e14fa5644304173", 
+      "nmdc:fe964169df2eccb05f25491090748cc5", 
+      "nmdc:60c0ee336af5cc2039c3f7273e00975a", 
+      "nmdc:ed394322e9312dba63b271c7484797a9"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321300", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:724f98d56bbda5686819251b3d35b3bb", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:80f3a59b2e11321064f589ec0dd1ceea"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321301", 
+    "has_output": [
+      "nmdc:23f685792e01b19b7d4c7c9a592e3fc9", 
+      "nmdc:088296d001a191fdba4af60837e4918b", 
+      "nmdc:fd1989f8cf71ca897641a46524242bd0", 
+      "nmdc:fecf564c2c3f7150ad596624178c8c10", 
+      "nmdc:9cfd08fa7dac9d59c866d32fbcd79e8f"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321301", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:b8865de68b6a30e28e9232a1184e4703", 
+    "ended_at_time": "2021-01-12"
+  }, 
+  {
+    "has_input": [
+      "nmdc:4ce9a799923b238585fc952135e5a0f5"
+    ], 
+    "git_url": "https://img.jgi.doe.gov", 
+    "name": "MetagenomeAnnotation activity for gold:Gp0321302", 
+    "has_output": [
+      "nmdc:033adebfc63b7f5cd1a0a590c8018281", 
+      "nmdc:6388680dcab4a88c07f21c91777b782d", 
+      "nmdc:5307f9b714e36dee8bf55e3e197ec9b9", 
+      "nmdc:934ee6e733522628856c63b94e5527a3", 
+      "nmdc:9a583be5f87563056c19eb94042bf19d"
+    ], 
+    "started_at_time": "2021-01-01", 
+    "was_informed_by": "gold:Gp0321302", 
+    "execution_resource": "NERSC - Cori", 
+    "type": "nmdc:MetagenomeAnnotation", 
+    "id": "nmdc:449b5471dff17853621e8dcd4e46d790", 
+    "ended_at_time": "2021-01-12"
+  }
+]
+}

--- a/schema/mixs.yaml
+++ b/schema/mixs.yaml
@@ -1245,7 +1245,7 @@ slots:
     in_subset:
       - sequencing
 
-  url:
+  mixs_url:
     aliases:
       - relevant electronic resources
     description: >-
@@ -1254,7 +1254,7 @@ slots:
     is_a: attribute
     range: text value  ## syntax: {URL}
     mappings:
-      - MIxS:url
+      - MIxS:mixs_url
     in_subset:
       - sequencing
 

--- a/schema/nmdc.py
+++ b/schema/nmdc.py
@@ -1,5 +1,5 @@
 # Auto generated from nmdc.yaml by pythongen.py version: 0.9.0
-# Generation date: 2021-01-13 13:41
+# Generation date: 2021-01-14 10:03
 # Schema: NMDC
 #
 # id: https://microbiomedata/schema
@@ -152,35 +152,35 @@ class EnvironmentalMaterialTermId(OntologyClassId):
     pass
 
 
-class ActivityActivityId(extended_str):
+class ActivityId(extended_str):
     pass
 
 
-class WorkflowExecutionActivityActivityId(ActivityActivityId):
+class WorkflowExecutionActivityId(ActivityId):
     pass
 
 
-class MetagenomeAssemblyActivityId(WorkflowExecutionActivityActivityId):
+class MetagenomeAssemblyId(WorkflowExecutionActivityId):
     pass
 
 
-class MetagenomeAnnotationActivityActivityId(WorkflowExecutionActivityActivityId):
+class MetagenomeAnnotationActivityId(WorkflowExecutionActivityId):
     pass
 
 
-class MAGAnnotationActivityActivityId(WorkflowExecutionActivityActivityId):
+class MAGAnnotationActivityId(WorkflowExecutionActivityId):
     pass
 
 
-class ReadQCAnalysisActivityActivityId(WorkflowExecutionActivityActivityId):
+class ReadQCAnalysisActivityId(WorkflowExecutionActivityId):
     pass
 
 
-class MetabolomicsAnalysisActivityActivityId(WorkflowExecutionActivityActivityId):
+class MetabolomicsAnalysisActivityId(WorkflowExecutionActivityId):
     pass
 
 
-class MetaproteomicsAnalysisActivityActivityId(WorkflowExecutionActivityActivityId):
+class MetaproteomicsAnalysisActivityId(WorkflowExecutionActivityId):
     pass
 
 
@@ -221,7 +221,7 @@ class Database(YAMLRoot):
     biosample_set: Optional[Union[Dict[Union[str, BiosampleId], Union[dict, "Biosample"]], List[Union[dict, "Biosample"]]]] = empty_dict()
     study_set: Optional[Union[Dict[Union[str, StudyId], Union[dict, "Study"]], List[Union[dict, "Study"]]]] = empty_dict()
     data_object_set: Optional[Union[Dict[Union[str, DataObjectId], Union[dict, "DataObject"]], List[Union[dict, "DataObject"]]]] = empty_dict()
-    activity_set: Optional[Union[Dict[Union[str, ActivityActivityId], Union[dict, "Activity"]], List[Union[dict, "Activity"]]]] = empty_dict()
+    activity_set: Optional[Union[Dict[Union[str, WorkflowExecutionActivityId], Union[dict, "WorkflowExecutionActivity"]], List[Union[dict, "WorkflowExecutionActivity"]]]] = empty_dict()
     omics_processing_set: Optional[Union[Dict[Union[str, OmicsProcessingId], Union[dict, "OmicsProcessing"]], List[Union[dict, "OmicsProcessing"]]]] = empty_dict()
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
@@ -247,7 +247,7 @@ class Database(YAMLRoot):
             self.activity_set = []
         if not isinstance(self.activity_set, (list, dict)):
             self.activity_set = [self.activity_set]
-        self._normalize_inlined_slot(slot_name="activity_set", slot_type=Activity, key_name="activity id", inlined_as_list=None, keyed=True)
+        self._normalize_inlined_slot(slot_name="activity_set", slot_type=WorkflowExecutionActivity, key_name="id", inlined_as_list=None, keyed=True)
 
         if self.omics_processing_set is None:
             self.omics_processing_set = []
@@ -424,7 +424,7 @@ class DataObject(NamedThing):
     data_object_type: Optional[Union[dict, "ControlledTermValue"]] = None
     compression_type: Optional[str] = None
     was_generated_by: Optional[Union[dict, "WorkflowExecutionActivity"]] = None
-    url: Optional[Union[dict, "TextValue"]] = None
+    url: Optional[str] = None
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
         if self.id is None:
@@ -447,8 +447,8 @@ class DataObject(NamedThing):
         if self.was_generated_by is not None and not isinstance(self.was_generated_by, WorkflowExecutionActivity):
             self.was_generated_by = WorkflowExecutionActivity(self.was_generated_by)
 
-        if self.url is not None and not isinstance(self.url, TextValue):
-            self.url = TextValue(**self.url)
+        if self.url is not None and not isinstance(self.url, str):
+            self.url = str(self.url)
 
         super().__post_init__(**kwargs)
 
@@ -984,14 +984,14 @@ class AttributeValue(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = NMDC.AttributeValue
 
     has_raw_value: Optional[str] = None
-    was_generated_by: Optional[Union[str, ActivityActivityId]] = None
+    was_generated_by: Optional[Union[str, ActivityId]] = None
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
         if self.has_raw_value is not None and not isinstance(self.has_raw_value, str):
             self.has_raw_value = str(self.has_raw_value)
 
-        if self.was_generated_by is not None and not isinstance(self.was_generated_by, ActivityActivityId):
-            self.was_generated_by = ActivityActivityId(self.was_generated_by)
+        if self.was_generated_by is not None and not isinstance(self.was_generated_by, ActivityId):
+            self.was_generated_by = ActivityId(self.was_generated_by)
 
         super().__post_init__(**kwargs)
 
@@ -1239,18 +1239,26 @@ class Activity(YAMLRoot):
     class_name: ClassVar[str] = "activity"
     class_model_uri: ClassVar[URIRef] = NMDC.Activity
 
-    activity_id: Union[str, ActivityActivityId] = None
+    id: Union[str, ActivityId] = None
+    name: Optional[str] = None
+    type: Optional[str] = None
     started_at_time: Optional[str] = None
     ended_at_time: Optional[str] = None
-    was_informed_by: Optional[Union[str, ActivityActivityId]] = None
+    was_informed_by: Optional[Union[str, ActivityId]] = None
     was_associated_with: Optional[Union[dict, "Agent"]] = None
     used: Optional[str] = None
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
-        if self.activity_id is None:
-            raise ValueError("activity_id must be supplied")
-        if not isinstance(self.activity_id, ActivityActivityId):
-            self.activity_id = ActivityActivityId(self.activity_id)
+        if self.id is None:
+            raise ValueError("id must be supplied")
+        if not isinstance(self.id, ActivityId):
+            self.id = ActivityId(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.type is not None and not isinstance(self.type, str):
+            self.type = str(self.type)
 
         if self.started_at_time is not None and not isinstance(self.started_at_time, str):
             self.started_at_time = str(self.started_at_time)
@@ -1258,8 +1266,8 @@ class Activity(YAMLRoot):
         if self.ended_at_time is not None and not isinstance(self.ended_at_time, str):
             self.ended_at_time = str(self.ended_at_time)
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, ActivityActivityId):
-            self.was_informed_by = ActivityActivityId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, ActivityId):
+            self.was_informed_by = ActivityId(self.was_informed_by)
 
         if self.was_associated_with is not None and not isinstance(self.was_associated_with, Agent):
             self.was_associated_with = Agent(**self.was_associated_with)
@@ -1282,17 +1290,17 @@ class WorkflowExecutionActivity(Activity):
     class_name: ClassVar[str] = "workflow execution activity"
     class_model_uri: ClassVar[URIRef] = NMDC.WorkflowExecutionActivity
 
-    activity_id: Union[str, WorkflowExecutionActivityActivityId] = None
+    id: Union[str, WorkflowExecutionActivityId] = None
     execution_resource: Optional[str] = None
     git_url: Optional[str] = None
     has_input: Optional[Union[str, List[str]]] = empty_list()
     has_output: Optional[Union[str, List[str]]] = empty_list()
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
-        if self.activity_id is None:
-            raise ValueError("activity_id must be supplied")
-        if not isinstance(self.activity_id, WorkflowExecutionActivityActivityId):
-            self.activity_id = WorkflowExecutionActivityActivityId(self.activity_id)
+        if self.id is None:
+            raise ValueError("id must be supplied")
+        if not isinstance(self.id, WorkflowExecutionActivityId):
+            self.id = WorkflowExecutionActivityId(self.id)
 
         if self.execution_resource is not None and not isinstance(self.execution_resource, str):
             self.execution_resource = str(self.execution_resource)
@@ -1324,7 +1332,7 @@ class MetagenomeAssembly(WorkflowExecutionActivity):
     class_name: ClassVar[str] = "metagenome assembly"
     class_model_uri: ClassVar[URIRef] = NMDC.MetagenomeAssembly
 
-    activity_id: Union[str, MetagenomeAssemblyActivityId] = None
+    id: Union[str, MetagenomeAssemblyId] = None
     asm_score: Optional[float] = None
     scaffolds: Optional[float] = None
     scaf_logsum: Optional[float] = None
@@ -1354,10 +1362,10 @@ class MetagenomeAssembly(WorkflowExecutionActivity):
     num_aligned_reads: Optional[float] = None
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
-        if self.activity_id is None:
-            raise ValueError("activity_id must be supplied")
-        if not isinstance(self.activity_id, MetagenomeAssemblyActivityId):
-            self.activity_id = MetagenomeAssemblyActivityId(self.activity_id)
+        if self.id is None:
+            raise ValueError("id must be supplied")
+        if not isinstance(self.id, MetagenomeAssemblyId):
+            self.id = MetagenomeAssemblyId(self.id)
 
         if self.asm_score is not None and not isinstance(self.asm_score, float):
             self.asm_score = float(self.asm_score)
@@ -1452,13 +1460,13 @@ class MetagenomeAnnotationActivity(WorkflowExecutionActivity):
     class_name: ClassVar[str] = "metagenome annotation activity"
     class_model_uri: ClassVar[URIRef] = NMDC.MetagenomeAnnotationActivity
 
-    activity_id: Union[str, MetagenomeAnnotationActivityActivityId] = None
+    id: Union[str, MetagenomeAnnotationActivityId] = None
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
-        if self.activity_id is None:
-            raise ValueError("activity_id must be supplied")
-        if not isinstance(self.activity_id, MetagenomeAnnotationActivityActivityId):
-            self.activity_id = MetagenomeAnnotationActivityActivityId(self.activity_id)
+        if self.id is None:
+            raise ValueError("id must be supplied")
+        if not isinstance(self.id, MetagenomeAnnotationActivityId):
+            self.id = MetagenomeAnnotationActivityId(self.id)
 
         super().__post_init__(**kwargs)
 
@@ -1472,16 +1480,16 @@ class MAGAnnotationActivity(WorkflowExecutionActivity):
     class_name: ClassVar[str] = "MAG annotation activity"
     class_model_uri: ClassVar[URIRef] = NMDC.MAGAnnotationActivity
 
-    activity_id: Union[str, MAGAnnotationActivityActivityId] = None
+    id: Union[str, MAGAnnotationActivityId] = None
     input_contig_num: Optional[int] = None
     binned_contig_num: Optional[int] = None
     too_short_contig_num: Optional[int] = None
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
-        if self.activity_id is None:
-            raise ValueError("activity_id must be supplied")
-        if not isinstance(self.activity_id, MAGAnnotationActivityActivityId):
-            self.activity_id = MAGAnnotationActivityActivityId(self.activity_id)
+        if self.id is None:
+            raise ValueError("id must be supplied")
+        if not isinstance(self.id, MAGAnnotationActivityId):
+            self.id = MAGAnnotationActivityId(self.id)
 
         if self.input_contig_num is not None and not isinstance(self.input_contig_num, int):
             self.input_contig_num = int(self.input_contig_num)
@@ -1504,17 +1512,17 @@ class ReadQCAnalysisActivity(WorkflowExecutionActivity):
     class_name: ClassVar[str] = "read QC analysis activity"
     class_model_uri: ClassVar[URIRef] = NMDC.ReadQCAnalysisActivity
 
-    activity_id: Union[str, ReadQCAnalysisActivityActivityId] = None
+    id: Union[str, ReadQCAnalysisActivityId] = None
     input_read_count: Optional[float] = None
     input_base_count: Optional[float] = None
     output_read_count: Optional[float] = None
     output_base_count: Optional[float] = None
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
-        if self.activity_id is None:
-            raise ValueError("activity_id must be supplied")
-        if not isinstance(self.activity_id, ReadQCAnalysisActivityActivityId):
-            self.activity_id = ReadQCAnalysisActivityActivityId(self.activity_id)
+        if self.id is None:
+            raise ValueError("id must be supplied")
+        if not isinstance(self.id, ReadQCAnalysisActivityId):
+            self.id = ReadQCAnalysisActivityId(self.id)
 
         if self.input_read_count is not None and not isinstance(self.input_read_count, float):
             self.input_read_count = float(self.input_read_count)
@@ -1540,15 +1548,15 @@ class MetabolomicsAnalysisActivity(WorkflowExecutionActivity):
     class_name: ClassVar[str] = "metabolomics analysis activity"
     class_model_uri: ClassVar[URIRef] = NMDC.MetabolomicsAnalysisActivity
 
-    activity_id: Union[str, MetabolomicsAnalysisActivityActivityId] = None
+    id: Union[str, MetabolomicsAnalysisActivityId] = None
     used: Optional[Union[str, InstrumentId]] = None
     has_metabolite_quantifications: Optional[Union[Union[dict, "MetaboliteQuantification"], List[Union[dict, "MetaboliteQuantification"]]]] = empty_list()
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
-        if self.activity_id is None:
-            raise ValueError("activity_id must be supplied")
-        if not isinstance(self.activity_id, MetabolomicsAnalysisActivityActivityId):
-            self.activity_id = MetabolomicsAnalysisActivityActivityId(self.activity_id)
+        if self.id is None:
+            raise ValueError("id must be supplied")
+        if not isinstance(self.id, MetabolomicsAnalysisActivityId):
+            self.id = MetabolomicsAnalysisActivityId(self.id)
 
         if self.used is not None and not isinstance(self.used, InstrumentId):
             self.used = InstrumentId(self.used)
@@ -1571,15 +1579,15 @@ class MetaproteomicsAnalysisActivity(WorkflowExecutionActivity):
     class_name: ClassVar[str] = "metaproteomics analysis activity"
     class_model_uri: ClassVar[URIRef] = NMDC.MetaproteomicsAnalysisActivity
 
-    activity_id: Union[str, MetaproteomicsAnalysisActivityActivityId] = None
+    id: Union[str, MetaproteomicsAnalysisActivityId] = None
     used: Optional[Union[str, InstrumentId]] = None
     has_peptide_quantifications: Optional[Union[Union[dict, "PeptideQuantification"], List[Union[dict, "PeptideQuantification"]]]] = empty_list()
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
-        if self.activity_id is None:
-            raise ValueError("activity_id must be supplied")
-        if not isinstance(self.activity_id, MetaproteomicsAnalysisActivityActivityId):
-            self.activity_id = MetaproteomicsAnalysisActivityActivityId(self.activity_id)
+        if self.id is None:
+            raise ValueError("id must be supplied")
+        if not isinstance(self.id, MetaproteomicsAnalysisActivityId):
+            self.id = MetaproteomicsAnalysisActivityId(self.id)
 
         if self.used is not None and not isinstance(self.used, InstrumentId):
             self.used = InstrumentId(self.used)
@@ -1606,14 +1614,14 @@ class Agent(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = NMDC.Agent
 
     acted_on_behalf_of: Optional[Union[dict, "Agent"]] = None
-    was_informed_by: Optional[Union[str, ActivityActivityId]] = None
+    was_informed_by: Optional[Union[str, ActivityId]] = None
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
         if self.acted_on_behalf_of is not None and not isinstance(self.acted_on_behalf_of, Agent):
             self.acted_on_behalf_of = Agent(**self.acted_on_behalf_of)
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, ActivityActivityId):
-            self.was_informed_by = ActivityActivityId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, ActivityId):
+            self.was_informed_by = ActivityId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
 
@@ -1899,13 +1907,13 @@ class FunctionalAnnotation(YAMLRoot):
     class_name: ClassVar[str] = "functional annotation"
     class_model_uri: ClassVar[URIRef] = NMDC.FunctionalAnnotation
 
-    was_generated_by: Optional[Union[str, ActivityActivityId]] = None
+    was_generated_by: Optional[Union[str, MetagenomeAnnotationActivityId]] = None
     subject: Optional[Union[dict, GeneProduct]] = None
     has_function: Optional[Union[str, FunctionalAnnotationTermId]] = None
 
     def __post_init__(self, **kwargs: Dict[str, Any]):
-        if self.was_generated_by is not None and not isinstance(self.was_generated_by, ActivityActivityId):
-            self.was_generated_by = ActivityActivityId(self.was_generated_by)
+        if self.was_generated_by is not None and not isinstance(self.was_generated_by, MetagenomeAnnotationActivityId):
+            self.was_generated_by = MetagenomeAnnotationActivityId(self.was_generated_by)
 
         if self.subject is not None and not isinstance(self.subject, GeneProduct):
             self.subject = GeneProduct()
@@ -1931,7 +1939,7 @@ slots.data_object_set = Slot(uri=NMDC.data_object_set, name="data object set", c
                    model_uri=NMDC.data_object_set, domain=Database, range=Optional[Union[Dict[Union[str, DataObjectId], Union[dict, "DataObject"]], List[Union[dict, "DataObject"]]]])
 
 slots.activity_set = Slot(uri=NMDC.activity_set, name="activity set", curie=NMDC.curie('activity_set'),
-                   model_uri=NMDC.activity_set, domain=Database, range=Optional[Union[Dict[Union[str, ActivityActivityId], Union[dict, "Activity"]], List[Union[dict, "Activity"]]]])
+                   model_uri=NMDC.activity_set, domain=Database, range=Optional[Union[Dict[Union[str, WorkflowExecutionActivityId], Union[dict, "WorkflowExecutionActivity"]], List[Union[dict, "WorkflowExecutionActivity"]]]])
 
 slots.omics_processing_set = Slot(uri=NMDC.omics_processing_set, name="omics processing set", curie=NMDC.curie('omics_processing_set'),
                    model_uri=NMDC.omics_processing_set, domain=Database, range=Optional[Union[Dict[Union[str, OmicsProcessingId], Union[dict, "OmicsProcessing"]], List[Union[dict, "OmicsProcessing"]]]])
@@ -1959,6 +1967,9 @@ slots.part_of = Slot(uri=DCTERMS.isPartOf, name="part of", curie=DCTERMS.curie('
 
 slots.execution_resource = Slot(uri=NMDC.execution_resource, name="execution resource", curie=NMDC.curie('execution_resource'),
                    model_uri=NMDC.execution_resource, domain=None, range=Optional[str])
+
+slots.url = Slot(uri=NMDC.url, name="url", curie=NMDC.curie('url'),
+                   model_uri=NMDC.url, domain=None, range=Optional[str])
 
 slots.git_url = Slot(uri=NMDC.git_url, name="git url", curie=NMDC.curie('git_url'),
                    model_uri=NMDC.git_url, domain=None, range=Optional[str])
@@ -2495,8 +2506,8 @@ slots.host_pred_appr = Slot(uri="str(uriorcurie)", name="host_pred_appr", curie=
 slots.host_pred_est_acc = Slot(uri="str(uriorcurie)", name="host_pred_est_acc", curie=None,
                    model_uri=NMDC.host_pred_est_acc, domain=None, range=Optional[Union[dict, TextValue]], mappings = [MIXS.host_pred_est_acc])
 
-slots.url = Slot(uri="str(uriorcurie)", name="url", curie=None,
-                   model_uri=NMDC.url, domain=None, range=Optional[Union[dict, TextValue]], mappings = [MIXS.url])
+slots.mixs_url = Slot(uri="str(uriorcurie)", name="mixs_url", curie=None,
+                   model_uri=NMDC.mixs_url, domain=None, range=Optional[Union[dict, TextValue]], mappings = [MIXS.mixs_url])
 
 slots.sop = Slot(uri="str(uriorcurie)", name="sop", curie=None,
                    model_uri=NMDC.sop, domain=None, range=Optional[Union[dict, TextValue]], mappings = [MIXS.sop])
@@ -4357,9 +4368,6 @@ slots.term = Slot(uri=RDF.type, name="term", curie=RDF.curie('type'),
 slots.orcid = Slot(uri=NMDC.orcid, name="orcid", curie=NMDC.curie('orcid'),
                    model_uri=NMDC.orcid, domain=PersonValue, range=Optional[str])
 
-slots.activity_id = Slot(uri=NMDC.activity_id, name="activity id", curie=NMDC.curie('activity_id'),
-                   model_uri=NMDC.activity_id, domain=None, range=URIRef)
-
 slots.started_at_time = Slot(uri=NMDC.started_at_time, name="started at time", curie=NMDC.curie('started_at_time'),
                    model_uri=NMDC.started_at_time, domain=None, range=Optional[str], mappings = [PROV.startedAtTime])
 
@@ -4367,7 +4375,7 @@ slots.ended_at_time = Slot(uri=NMDC.ended_at_time, name="ended at time", curie=N
                    model_uri=NMDC.ended_at_time, domain=None, range=Optional[str], mappings = [PROV.endedAtTime])
 
 slots.was_informed_by = Slot(uri=NMDC.was_informed_by, name="was informed by", curie=NMDC.curie('was_informed_by'),
-                   model_uri=NMDC.was_informed_by, domain=None, range=Optional[Union[str, ActivityActivityId]], mappings = [PROV.wasInformedBy])
+                   model_uri=NMDC.was_informed_by, domain=None, range=Optional[Union[str, ActivityId]], mappings = [PROV.wasInformedBy])
 
 slots.was_associated_with = Slot(uri=NMDC.was_associated_with, name="was associated with", curie=NMDC.curie('was_associated_with'),
                    model_uri=NMDC.was_associated_with, domain=None, range=Optional[Union[dict, Agent]], mappings = [PROV.wasAssociatedWith])
@@ -4376,7 +4384,7 @@ slots.acted_on_behalf_of = Slot(uri=NMDC.acted_on_behalf_of, name="acted on beha
                    model_uri=NMDC.acted_on_behalf_of, domain=None, range=Optional[Union[dict, Agent]], mappings = [PROV.actedOnBehalfOf])
 
 slots.was_generated_by = Slot(uri=NMDC.was_generated_by, name="was generated by", curie=NMDC.curie('was_generated_by'),
-                   model_uri=NMDC.was_generated_by, domain=None, range=Optional[Union[str, ActivityActivityId]], mappings = [PROV.wasGeneratedBy])
+                   model_uri=NMDC.was_generated_by, domain=None, range=Optional[Union[str, ActivityId]], mappings = [PROV.wasGeneratedBy])
 
 slots.used = Slot(uri=NMDC.used, name="used", curie=NMDC.curie('used'),
                    model_uri=NMDC.used, domain=Activity, range=Optional[str], mappings = [PROV.used])
@@ -4701,4 +4709,4 @@ slots.functional_annotation_has_function = Slot(uri=NMDC.has_function, name="fun
                    model_uri=NMDC.functional_annotation_has_function, domain=FunctionalAnnotation, range=Optional[Union[str, FunctionalAnnotationTermId]])
 
 slots.functional_annotation_was_generated_by = Slot(uri=NMDC.was_generated_by, name="functional annotation_was generated by", curie=NMDC.curie('was_generated_by'),
-                   model_uri=NMDC.functional_annotation_was_generated_by, domain=FunctionalAnnotation, range=Optional[Union[str, ActivityActivityId]])
+                   model_uri=NMDC.functional_annotation_was_generated_by, domain=FunctionalAnnotation, range=Optional[Union[str, MetagenomeAnnotationActivityId]])

--- a/schema/nmdc.schema.json
+++ b/schema/nmdc.schema.json
@@ -6,13 +6,22 @@
          "additionalProperties": false,
          "description": "a provence-generating activity",
          "properties": {
-            "activity_id": {
-               "type": "string"
-            },
             "ended_at_time": {
                "type": "string"
             },
+            "id": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "name": {
+               "description": "A human readable label for an entity",
+               "type": "string"
+            },
             "started_at_time": {
+               "type": "string"
+            },
+            "type": {
+               "description": "The type of entity that the json object represents.  This is used to allow for searches for different kinds of objects.",
                "type": "string"
             },
             "used": {
@@ -26,7 +35,7 @@
             }
          },
          "required": [
-            "activity_id"
+            "id"
          ],
          "title": "Activity",
          "type": "object"
@@ -535,7 +544,7 @@
                "type": "string"
             },
             "url": {
-               "$ref": "#/definitions/TextValue"
+               "type": "string"
             },
             "was_generated_by": {
                "$ref": "#/definitions/WorkflowExecutionActivity",
@@ -555,7 +564,7 @@
             "activity_set": {
                "description": "This property links a database object to the set of prov activities.",
                "items": {
-                  "$ref": "#/definitions/Activity"
+                  "$ref": "#/definitions/WorkflowExecutionActivity"
                },
                "type": "array"
             },
@@ -633,7 +642,7 @@
                "$ref": "#/definitions/GeneProduct"
             },
             "was_generated_by": {
-               "description": "provenance for the annotation. Note to be consistent with the rest of the NMDC schema we use the PROV annotation model, rather than GPAD",
+               "description": "provenance for the annotation.",
                "type": "string"
             }
          },
@@ -768,9 +777,6 @@
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "activity_id": {
-               "type": "string"
-            },
             "binned_contig_num": {
                "type": "integer"
             },
@@ -799,14 +805,26 @@
                },
                "type": "array"
             },
+            "id": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
             "input_contig_num": {
                "type": "integer"
+            },
+            "name": {
+               "description": "A human readable label for an entity",
+               "type": "string"
             },
             "started_at_time": {
                "type": "string"
             },
             "too_short_contig_num": {
                "type": "integer"
+            },
+            "type": {
+               "description": "The type of entity that the json object represents.  This is used to allow for searches for different kinds of objects.",
+               "type": "string"
             },
             "used": {
                "type": "string"
@@ -819,7 +837,7 @@
             }
          },
          "required": [
-            "activity_id"
+            "id"
          ],
          "title": "MAGAnnotationActivity",
          "type": "object"
@@ -845,9 +863,6 @@
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "activity_id": {
-               "type": "string"
-            },
             "ended_at_time": {
                "type": "string"
             },
@@ -879,7 +894,19 @@
                },
                "type": "array"
             },
+            "id": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "name": {
+               "description": "A human readable label for an entity",
+               "type": "string"
+            },
             "started_at_time": {
+               "type": "string"
+            },
+            "type": {
+               "description": "The type of entity that the json object represents.  This is used to allow for searches for different kinds of objects.",
                "type": "string"
             },
             "used": {
@@ -894,7 +921,7 @@
             }
          },
          "required": [
-            "activity_id"
+            "id"
          ],
          "title": "MetabolomicsAnalysisActivity",
          "type": "object"
@@ -903,9 +930,6 @@
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "activity_id": {
-               "type": "string"
-            },
             "ended_at_time": {
                "type": "string"
             },
@@ -931,7 +955,19 @@
                },
                "type": "array"
             },
+            "id": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "name": {
+               "description": "A human readable label for an entity",
+               "type": "string"
+            },
             "started_at_time": {
+               "type": "string"
+            },
+            "type": {
+               "description": "The type of entity that the json object represents.  This is used to allow for searches for different kinds of objects.",
                "type": "string"
             },
             "used": {
@@ -945,7 +981,7 @@
             }
          },
          "required": [
-            "activity_id"
+            "id"
          ],
          "title": "MetagenomeAnnotationActivity",
          "type": "object"
@@ -954,9 +990,6 @@
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "activity_id": {
-               "type": "string"
-            },
             "asm_score": {
                "description": "A score for comparing metagenomic assembly quality from same sample.",
                "type": "number"
@@ -1034,6 +1067,14 @@
                },
                "type": "array"
             },
+            "id": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "name": {
+               "description": "A human readable label for an entity",
+               "type": "string"
+            },
             "num_aligned_reads": {
                "description": "The sequence count number of input reads aligned to assembled contigs.",
                "type": "number"
@@ -1093,6 +1134,10 @@
             "started_at_time": {
                "type": "string"
             },
+            "type": {
+               "description": "The type of entity that the json object represents.  This is used to allow for searches for different kinds of objects.",
+               "type": "string"
+            },
             "used": {
                "type": "string"
             },
@@ -1104,7 +1149,7 @@
             }
          },
          "required": [
-            "activity_id"
+            "id"
          ],
          "title": "MetagenomeAssembly",
          "type": "object"
@@ -1113,9 +1158,6 @@
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "activity_id": {
-               "type": "string"
-            },
             "ended_at_time": {
                "type": "string"
             },
@@ -1147,7 +1189,19 @@
                },
                "type": "array"
             },
+            "id": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "name": {
+               "description": "A human readable label for an entity",
+               "type": "string"
+            },
             "started_at_time": {
+               "type": "string"
+            },
+            "type": {
+               "description": "The type of entity that the json object represents.  This is used to allow for searches for different kinds of objects.",
                "type": "string"
             },
             "used": {
@@ -1162,7 +1216,7 @@
             }
          },
          "required": [
-            "activity_id"
+            "id"
          ],
          "title": "MetaproteomicsAnalysisActivity",
          "type": "object"
@@ -1540,9 +1594,6 @@
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "activity_id": {
-               "type": "string"
-            },
             "ended_at_time": {
                "type": "string"
             },
@@ -1568,6 +1619,10 @@
                },
                "type": "array"
             },
+            "id": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
             "input_base_count": {
                "description": "The nucleotide base count number of input reads for QC analysis.",
                "type": "number"
@@ -1575,6 +1630,10 @@
             "input_read_count": {
                "description": "The sequence count number of input reads for QC analysis.",
                "type": "number"
+            },
+            "name": {
+               "description": "A human readable label for an entity",
+               "type": "string"
             },
             "output_base_count": {
                "description": "After QC analysis nucleotide base count number.",
@@ -1585,6 +1644,10 @@
                "type": "number"
             },
             "started_at_time": {
+               "type": "string"
+            },
+            "type": {
+               "description": "The type of entity that the json object represents.  This is used to allow for searches for different kinds of objects.",
                "type": "string"
             },
             "used": {
@@ -1598,7 +1661,7 @@
             }
          },
          "required": [
-            "activity_id"
+            "id"
          ],
          "title": "ReadQCAnalysisActivity",
          "type": "object"
@@ -1716,9 +1779,6 @@
          "additionalProperties": false,
          "description": "Represents an instance of an execution of a particular workflow",
          "properties": {
-            "activity_id": {
-               "type": "string"
-            },
             "ended_at_time": {
                "type": "string"
             },
@@ -1744,7 +1804,19 @@
                },
                "type": "array"
             },
+            "id": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "name": {
+               "description": "A human readable label for an entity",
+               "type": "string"
+            },
             "started_at_time": {
+               "type": "string"
+            },
+            "type": {
+               "description": "The type of entity that the json object represents.  This is used to allow for searches for different kinds of objects.",
                "type": "string"
             },
             "used": {
@@ -1758,7 +1830,7 @@
             }
          },
          "required": [
-            "activity_id"
+            "id"
          ],
          "title": "WorkflowExecutionActivity",
          "type": "object"
@@ -1768,7 +1840,7 @@
       "activity_set": {
          "description": "This property links a database object to the set of prov activities.",
          "items": {
-            "$ref": "#/definitions/Activity"
+            "$ref": "#/definitions/WorkflowExecutionActivity"
          },
          "type": "array"
       },

--- a/schema/nmdc.yaml
+++ b/schema/nmdc.yaml
@@ -511,7 +511,7 @@ slots:
   
   activity set:
     domain: database
-    range: activity
+    range: workflow execution activity
     multivalued: true
     inlined: true
     description: >-
@@ -587,6 +587,12 @@ slots:
     is_a: attribute
     description: >-
       Example: NERSC-Cori
+      
+  url:
+    is_a: attribute
+    range: string
+    notes:
+      - See issue 207 - this clashes with the mixs field
       
   git url:
     is_a: attribute

--- a/schema/prov.yaml
+++ b/schema/prov.yaml
@@ -25,7 +25,9 @@ classes:
   activity:
     description: "a provence-generating activity"
     slots:
-      - activity id
+      - id
+      - name
+      - type
       - started at time
       - ended at time
       - was informed by
@@ -44,9 +46,6 @@ classes:
       
 slots:
 
-  activity id:
-    identifier: true
-  
   started at time:
     mappings:
       - prov:startedAtTime

--- a/scripts/mixs-to-blml.pl
+++ b/scripts/mixs-to-blml.pl
@@ -1,6 +1,10 @@
 #!/usr/bin/perl -w
 use strict;
 
+our %REMAP = (
+    'url' => 'mixs_url',
+    );
+
 # THIS WILL BE REWRITTEN IN PYTHON!
 
 print "id: https://microbiomedata/schema/mixs\n\n";
@@ -93,6 +97,10 @@ while(<>) {
     }
     $done{$name} = 1;
 
+    if ($REMAP{$name}) {
+        $name = $REMAP{$name};
+    }
+    
     my $re = translate_re($value_syntax);
     if ($re) {
         $re =~ s@\\@\\\\@g;


### PR DESCRIPTION
Worked with @wdduncan on getting @scanon's examples in to the repo

 - copied the examples (an activity set and a data object set) from slack
 - added relevant "holders" (the top level object should be a dict with various lists; need to document this a bit better)
 - added these to the test suite
 - made changes to the schema in order for this to validate
     - we mistakenly had the 'id' for 'activity' be 'activity_id'. Now fixed to 'id'
     - workflow activities were being validated as activities, and so use of fields specific to workflow activities were not counted as valid. we made the activity list be a workflow activity list
  