### PR TITLE
add license info

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+This work is licensed under [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html).
+
+The NMDC schema content is also licensed under [CC0-1.0](https://spdx.org/licenses/CC0-1.0.html).
+You may select CC0-1.0 instead of Apache-2.0 for use of NMDC schema content.
+
+Data contributions are licensed under [CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html). The
+data contributor license agreement is available at
+<https://microbiomedata.org/nmdc-data-use-policy/>.
+
+# Apache-2.0
+
+Copyright 2021 The Regents of the University of California
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+# CC0-1.0
+
+Creative Commons Zero v1.0 Universal
+https://creativecommons.org/publicdomain/zero/1.0/legalcode


### PR DESCRIPTION
Apache-2.0 in general (for built-in contributor agreement), to cover software source and objects. CC0-1.0 available for schema content.

Also mentions existing policy that data contributions are licensed as CC-BY-4.0, and links to data contributor agreement.

Closes #317 